### PR TITLE
Allow mutating generator functions for points

### DIFF
--- a/rstar-demo/src/main.rs
+++ b/rstar-demo/src/main.rs
@@ -141,12 +141,7 @@ pub fn create_random_points<P: Point<Scalar = f32>>(num_points: usize) -> Vec<P>
     let mut rng = rand::thread_rng();
     let distribution = Uniform::new(-1.0f32, 1.0);
     for _ in 0..num_points {
-        let points: [f32; 3] = [
-            rng.sample(distribution),
-            rng.sample(distribution),
-            rng.sample(distribution),
-        ];
-        let new_point = P::generate(|i| points[i]);
+        let new_point = P::generate(|_| rng.sample(distribution));
         result.push(new_point);
     }
     result

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,9 +1,11 @@
-# 0.8.4 (unreleased)
+# 0.9.0 (unreleased)
 - Update CI images to Stable Rust 1.50 and 1.51
 - Run clippy, rustfmt, update manifest to reflect ownership changes
 - Update Criterion and rewrite deprecated benchmark functions
 - Add new `RTree::nearest_neighbors` method based on
   [the original implementation](https://github.com/Stoeoef/spade)
+- `Point::generate` function now accepts a `impl FnMut`. Custom implementations of `Point` must change to
+  accept `impl FnMut` instead of `impl Fn`. Callers of `Point::generate` should not require changes.
 
 # 0.8.3
 - Move crate ownership to the georust organization

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -190,7 +190,7 @@ pub trait PointExt: Point {
     fn component_wise(
         &self,
         other: &Self,
-        f: impl Fn(Self::Scalar, Self::Scalar) -> Self::Scalar,
+        mut f: impl FnMut(Self::Scalar, Self::Scalar) -> Self::Scalar,
     ) -> Self {
         Self::generate(|i| f(self.nth(i), other.nth(i)))
     }
@@ -199,7 +199,7 @@ pub trait PointExt: Point {
     fn all_component_wise(
         &self,
         other: &Self,
-        f: impl Fn(Self::Scalar, Self::Scalar) -> bool,
+        mut f: impl FnMut(Self::Scalar, Self::Scalar) -> bool,
     ) -> bool {
         // TODO: Maybe do this by proper iteration
         for i in 0..Self::DIMENSIONS {
@@ -223,7 +223,7 @@ pub trait PointExt: Point {
     /// The `start_value` is the value the accumulator will have on the first call of the closure.
     ///
     /// After applying the closure to every component of the Point, fold() returns the accumulator.
-    fn fold<T>(&self, start_value: T, f: impl Fn(T, Self::Scalar) -> T) -> T {
+    fn fold<T>(&self, start_value: T, mut f: impl FnMut(T, Self::Scalar) -> T) -> T {
         let mut accumulated = start_value;
         // TODO: Maybe do this by proper iteration
         for i in 0..Self::DIMENSIONS {
@@ -268,7 +268,7 @@ pub trait PointExt: Point {
     }
 
     /// Applies `f` to `self` component wise.
-    fn map(&self, f: impl Fn(Self::Scalar) -> Self::Scalar) -> Self {
+    fn map(&self, mut f: impl FnMut(Self::Scalar) -> Self::Scalar) -> Self {
         Self::generate(|i| f(self.nth(i)))
     }
 

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -127,7 +127,7 @@ impl<S> RTreeNum for S where S: Bounded + Num + Clone + Copy + Signed + PartialO
 ///   type Scalar = i32;
 ///   const DIMENSIONS: usize = 2;
 ///
-///   fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self
+///   fn generate(mut generator: impl FnMut(usize) -> Self::Scalar) -> Self
 ///   {
 ///     IntegerPoint {
 ///       x: generator(0),
@@ -164,8 +164,9 @@ pub trait Point: Copy + Clone + PartialEq + Debug {
     /// Creates a new point value with given values for each dimension.
     ///
     /// The value that each dimension should be initialized with is given by the parameter `generator`.
-    /// Calling `generator(n)` returns the value of dimension `n`, `n` will be in the range `0 .. Self::DIMENSIONS`.
-    fn generate(generator: impl Fn(usize) -> Self::Scalar) -> Self;
+    /// Calling `generator(n)` returns the value of dimension `n`, `n` will be in the range `0 .. Self::DIMENSIONS`,
+    /// and will be called with values of `n` in ascending order.
+    fn generate(generator: impl FnMut(usize) -> Self::Scalar) -> Self;
 
     /// Returns a single coordinate of this point.
     ///
@@ -317,7 +318,7 @@ macro_rules! implement_point_for_array {
 
             const DIMENSIONS: usize = count_exprs!($($index),*);
 
-            fn generate(generator: impl Fn(usize) -> S) -> Self
+            fn generate(mut generator: impl FnMut(usize) -> S) -> Self
             {
                 [$(generator($index)),*]
             }

--- a/rstar/src/test_utilities.rs
+++ b/rstar/src/test_utilities.rs
@@ -15,11 +15,7 @@ pub fn create_random_integers<P: Point<Scalar = i32>>(num_points: usize, seed: &
     let range = Uniform::from(-100_000..100_000);
 
     for _ in 0..num_points {
-        let buffer = range
-            .sample_iter(&mut rng)
-            .take(P::DIMENSIONS)
-            .collect::<Vec<_>>();
-        let p = Point::generate(|index| buffer[index]);
+        let p = Point::generate(|_| rng.sample(range));
         result.push(p);
     }
     result


### PR DESCRIPTION
This allows for additional flexibility for the caller, for example, code in the form of:

```rust
buffer = [f(), f(), f(), ..];
point = Point::generate(|i| buffer[i])
```

can be replaced with

```rust
point = Point::generate(|_| f())
```