### PR TITLE
Nearest neighbors

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
 - [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
-- [ ] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
+- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
 ---
 

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Update CI images to Stable Rust 1.50 and 1.51
 - Run clippy, rustfmt, update manifest to reflect ownership changes
 - Update Criterion and rewrite deprecated benchmark functions
+- Add new `RTree::nearest_neighbors` method based on
+  [the original implementation](https://github.com/Stoeoef/spade)
 
 # 0.8.3
 - Move crate ownership to the georust organization

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -242,6 +242,16 @@ where
     None
 }
 
+pub fn nearest_neighbors<'a, T>(
+    _node: &'a ParentNode<T>,
+    _query_point: <T::Envelope as Envelope>::Point,
+) -> Vec<&'a T>
+where
+    T: PointDistance,
+{
+    vec![]
+}
+
 #[cfg(test)]
 mod test {
     use crate::object::PointDistance;

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -292,6 +292,26 @@ mod test {
     }
 
     #[test]
+    fn test_nearest_neighbors() {
+        let points = create_random_points(1000, SEED_1);
+        let tree = RTree::bulk_load(points.clone());
+
+        let sample_points = create_random_points(50, SEED_2);
+        for sample_point in &sample_points {
+            let nearest_neighbors = tree.nearest_neighbors(sample_point);
+            let mut distance = -1.0;
+            for nn in &nearest_neighbors {
+                if distance < 0.0 {
+                    distance = sample_point.distance_2(nn);
+                } else {
+                    let new_distance = sample_point.distance_2(nn);
+                    assert_eq!(new_distance, distance);
+                }
+            }
+        }
+    }
+
+    #[test]
     fn test_nearest_neighbor_iterator() {
         let mut points = create_random_points(1000, SEED_1);
         let tree = RTree::bulk_load(points.clone());

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -276,6 +276,12 @@ mod test {
     }
 
     #[test]
+    fn test_nearest_neighbors_empty() {
+        let tree: RTree<[f32; 2]> = RTree::new();
+        assert!(tree.nearest_neighbors(&[0.0, 213.0]).is_empty());
+    }
+
+    #[test]
     fn test_nearest_neighbor_iterator() {
         let mut points = create_random_points(1000, SEED_1);
         let tree = RTree::bulk_load(points.clone());

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -627,8 +627,8 @@ where
     ///   [0.0, 1.0],
     ///   [1.0, 0.0],
     /// ]);
-    /// assert_eq!(tree.nearest_neighbors(&[1.0, 1.0]), &[&[1.0, 0.0], &[0.0, 1.0]]);
-    /// assert_eq!(tree.nearest_neighbors(&[0.01, 0.01]), &[&[0.0, 1.0]]);
+    /// assert_eq!(tree.nearest_neighbors(&[1.0, 1.0]), &[&[0.0, 1.0], &[1.0, 0.0]]);
+    /// assert_eq!(tree.nearest_neighbors(&[0.01, 0.01]), &[&[0.0, 0.0]]);
     /// ```
     pub fn nearest_neighbors(&self, query_point: &<T::Envelope as Envelope>::Point) -> Vec<&T> {
         nearest_neighbor::nearest_neighbors(&self.root, *query_point)

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -611,6 +611,29 @@ where
         }
     }
 
+    /// Returns the nearest neighbors for a given point.
+    ///
+    /// The distance is calculated by calling
+    /// [PointDistance::distance_2](traits.PointDistance.html#method.distance_2)
+    ///
+    /// All returned values will have the exact same distance from the given query point.
+    /// Returns an empty `Vec` if the tree is empty.
+    ///
+    /// # Example
+    /// ```
+    /// use rstar::RTree;
+    /// let tree = RTree::bulk_load(vec![
+    ///   [0.0, 0.0],
+    ///   [0.0, 1.0],
+    ///   [1.0, 0.0],
+    /// ]);
+    /// assert_eq!(tree.nearest_neighbors(&[1.0, 1.0]), &[&[1.0, 0.0], &[0.0, 1.0]]);
+    /// assert_eq!(tree.nearest_neighbors(&[0.01, 0.01]), &[&[0.0, 1.0]]);
+    /// ```
+    pub fn nearest_neighbors(&self, _query_point: &<T::Envelope as Envelope>::Point) -> Vec<&T> {
+        vec![]
+    }
+
     /// Returns all elements of the tree within a certain distance.
     ///
     /// The elements may be returned in any order. Each returned element

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -630,8 +630,8 @@ where
     /// assert_eq!(tree.nearest_neighbors(&[1.0, 1.0]), &[&[1.0, 0.0], &[0.0, 1.0]]);
     /// assert_eq!(tree.nearest_neighbors(&[0.01, 0.01]), &[&[0.0, 1.0]]);
     /// ```
-    pub fn nearest_neighbors(&self, _query_point: &<T::Envelope as Envelope>::Point) -> Vec<&T> {
-        vec![]
+    pub fn nearest_neighbors(&self, query_point: &<T::Envelope as Envelope>::Point) -> Vec<&T> {
+        nearest_neighbor::nearest_neighbors(&self.root, *query_point)
     }
 
     /// Returns all elements of the tree within a certain distance.


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---
Added the `RTree::nearest_neighbors` API, mimicking the [interface in spade](https://docs.rs/spade/1.8.2/spade/rtree/struct.RTree.html#method.nearest_neighbors), as per issue #30.

It leverages the existing `nearest_neighbor::NearestNeighborIterator` struct, as proposed by @Stoeoef.