### PR TITLE
Updates heapless dependency to 0.6 due to vulnerability

### DIFF
--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -17,7 +17,7 @@ codecov = { repository = "Stoeoef/rstar", branch = "master", service = "github" 
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-heapless = "0.5"
+heapless = "0.6"
 num-traits = "0.2"
 pdqselect = "0.1"
 serde = { version = "1.0", optional = true, features = ["derive"] }


### PR DESCRIPTION
From running `cargo-deny`
```
warning[A004]: Use-after-free when cloning a partially consumed `Vec` iterator
   ┌─ /.../Cargo.lock:56:1
   │
56 │ heapless 0.5.6 registry+https://github.com/rust-lang/crates.io-index
   │ -------------------------------------------------------------------- unsound advisory detected
   │
   = ID: RUSTSEC-2020-0145
   = Advisory: https://rustsec.org/advisories/RUSTSEC-2020-0145
   = The `IntoIter` `Clone` implementation clones the whole underlying `Vec`.
     If the iterator is partially consumed the consumed items will be copied, thus creating a use-after-free access.

     A proof of concept is available in the original bug report.
   = Announcement: https://github.com/japaric/heapless/issues/181
   = Solution: Upgrade to >=0.6.1
   = heapless v0.5.6
     └── rstar v0.8.2
```