### PR TITLE
Fix rstar-demo for aarch64 macos

### DIFF
--- a/rstar-demo/Cargo.toml
+++ b/rstar-demo/Cargo.toml
@@ -6,7 +6,12 @@ edition = "2018"
 
 [dependencies]
 rand = "0.7"
-kiss3d = "0.31"
-nalgebra = "0.26"
+# using a slightly older version of kiss3d/nalgebra 
+# Since these version require the new feature resolver and min-const-generics only
+# available in rust-1.51 See: https://github.com/dimforge/nalgebra/issues/875
+# kiss3d = "0.31"
+# nalgebra = "0.26"
+kiss3d = "0.30"
+nalgebra = "0.25"
 
 rstar = { path="../rstar" }

--- a/rstar-demo/Cargo.toml
+++ b/rstar-demo/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2018"
 
 [dependencies]
 rand = "0.7"
-kiss3d = "0.20"
-nalgebra = "0.18"
+kiss3d = "0.31"
+nalgebra = "0.26"
 
 rstar = { path="../rstar" }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [-] I added an entry to `CHANGES.md` if knowledge of this change could be valuable to users.
---

The current demo wasn't compiling on my machine - failing due to an old downstream dep of kiss3d (winit). Fixed by the update.

<img width="1136" alt="Screen Shot 2021-04-27 at 10 06 19 AM" src="https://user-images.githubusercontent.com/217057/116282966-37bfe300-a740-11eb-86f4-52069cda9f43.png">
