### PR TITLE
polish release notes

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,16 +1,22 @@
 # 0.9.0 (unreleased)
+
+## Added
+- `RTree::nearest_neighbors` method based on
+  [spade crate's implementation](https://github.com/Stoeoef/spade)
+
+## Changed
+- BREAKING: `Point::generate` function now accepts a `impl FnMut`. Custom implementations of `Point` must change to
+  accept `impl FnMut` instead of `impl Fn`. Callers of `Point::generate` should not require changes.
 - Update CI images to Stable Rust 1.50 and 1.51
 - Run clippy, rustfmt, update manifest to reflect ownership changes
 - Update Criterion and rewrite deprecated benchmark functions
-- Add new `RTree::nearest_neighbors` method based on
-  [the original implementation](https://github.com/Stoeoef/spade)
-- `Point::generate` function now accepts a `impl FnMut`. Custom implementations of `Point` must change to
-  accept `impl FnMut` instead of `impl Fn`. Callers of `Point::generate` should not require changes.
 - Remove unused imports
 - Remove executable bit from files
 
 # 0.8.3
+## Changed
 - Move crate ownership to the georust organization
+## Fixed
 - Update dependencies to remove heapless 0.5, which has a known vulnerability
 
 # 0.8.2 - 2020-08-01


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [- ] ~~I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users~~.
---


Stick with format of previous release notes, and follow the Fixed/Added/Changed categorization like outlined in https://keepachangelog.com

