### PR TITLE
Add a `SelectionWithDataIterator` trait that allows `should_unpack_leaf` to return `Option<Data>`

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Added
 - `RTree::nearest_neighbors` method based on
   [spade crate's implementation](https://github.com/Stoeoef/spade)
-- Added a `SelectionWithDataIterator` trait.
+- Added `RTree::locate_with_selection_function_with_data` and a `SelectionWithDataIterator` trait to go with it.
 
 ## Changed
 - BREAKING: `Point::generate` function now accepts a `impl FnMut`. Custom implementations of `Point` must change to

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 - `RTree::nearest_neighbors` method based on
   [spade crate's implementation](https://github.com/Stoeoef/spade)
+- Added a `SelectionWithDataIterator` trait.
 
 ## Changed
 - BREAKING: `Point::generate` function now accepts a `impl FnMut`. Custom implementations of `Point` must change to
@@ -35,7 +36,7 @@
 ## Changed:
  - Deprecated `RTree::nearest_neighbor_iter_with_distance`. The name is misleading, use `RTree::nearest_neighbor_iter_with_distance_2` instead.
  - Some performance improvements, see #38 and #35
- 
+
 ## Added
  - Added `nearest_neighbor_iter_with_distance_2` #31
 

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 - Add `RTree::drain_*` methods to remove and drain selected items. ([PR](https://github.com/georust/rstar/pull/77))
+- Added `RTree::locate_with_selection_function_with_data` and a `SelectionWithDataIterator` trait to go with it.
 
 ## Changed
 - Expose all iterator types in `crate::iterators` module ([PR](https://github.com/georust/rstar/pull/77))
@@ -16,7 +17,6 @@
 ## Added
 - `RTree::nearest_neighbors` method based on
   [spade crate's implementation](https://github.com/Stoeoef/spade)
-- Added `RTree::locate_with_selection_function_with_data` and a `SelectionWithDataIterator` trait to go with it.
 
 ## Changed
 - Fix floating point inconsistency in `min_max_dist_2` ([PR](https://github.com/georust/rstar/pull/40)).

--- a/rstar/src/algorithm/selection_functions.rs
+++ b/rstar/src/algorithm/selection_functions.rs
@@ -37,6 +37,22 @@ where
     }
 }
 
+/// Similar to [`SelectionFunction](#struct.SelectionFunction) but additional data can be returned by
+/// `should_unpack_leaf`.
+pub trait SelectionFunctionWithData<T, D>
+where
+    T: RTreeObject,
+{
+    /// Return `true` if a parent node should be unpacked during a search.
+    ///
+    /// The parent node's envelope is given to guide the decision.
+    fn should_unpack_parent(&self, envelope: &T::Envelope) -> bool;
+
+    /// Returns `Some(...)` with the additional data if a given child node
+    /// should be returned during a search.
+    fn should_unpack_leaf(&self, _leaf: &T) -> Option<D>;
+}
+
 pub struct SelectInEnvelopeFunction<T>
 where
     T: RTreeObject,

--- a/rstar/src/algorithm/selection_functions.rs
+++ b/rstar/src/algorithm/selection_functions.rs
@@ -37,7 +37,7 @@ where
     }
 }
 
-/// Similar to [`SelectionFunction](#struct.SelectionFunction) but additional data can be returned by
+/// Similar to [`SelectionFunction`](trait.SelectionFunction.html) but additional data can be returned by
 /// `should_unpack_leaf`.
 pub trait SelectionFunctionWithData<T, D>
 where

--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -38,7 +38,7 @@ mod test_utilities;
 
 pub use crate::aabb::AABB;
 pub use crate::algorithm::rstar::RStarInsertionStrategy;
-pub use crate::algorithm::selection_functions::SelectionFunction;
+pub use crate::algorithm::selection_functions::{SelectionFunction, SelectionFunctionWithData};
 pub use crate::envelope::Envelope;
 pub use crate::node::{ParentNode, RTreeNode};
 pub use crate::object::{PointDistance, RTreeObject};

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -379,6 +379,15 @@ where
         SelectionIterator::new(&self.root, selection_function)
     }
 
+    /// Similar to [`locate_with_selection_function`](#method.locate_with_selection_function) but with
+    /// a selection function that can return additional data.
+    pub fn locate_with_selection_function_with_data<D, S: SelectionFunctionWithData<T, D>>(
+        &self,
+        selection_function: S,
+    ) -> impl Iterator<Item = (&T, D)> {
+        SelectionWithDataIterator::new(&self.root, selection_function)
+    }
+
     /// Mutable variant of [`locate_with_selection_function`](#method.locate_with_selection_function).
     pub fn locate_with_selection_function_mut<S: SelectionFunction<T>>(
         &mut self,

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -379,6 +379,14 @@ where
         SelectionIterator::new(&self.root, selection_function)
     }
 
+    /// Mutable variant of [`locate_with_selection_function`](#method.locate_with_selection_function).
+    pub fn locate_with_selection_function_mut<S: SelectionFunction<T>>(
+        &mut self,
+        selection_function: S,
+    ) -> impl Iterator<Item = &mut T> {
+        SelectionIteratorMut::new(&mut self.root, selection_function)
+    }
+
     /// Similar to [`locate_with_selection_function`](#method.locate_with_selection_function) but with
     /// a selection function that can return additional data.
     pub fn locate_with_selection_function_with_data<D, S: SelectionFunctionWithData<T, D>>(
@@ -388,12 +396,12 @@ where
         SelectionWithDataIterator::new(&self.root, selection_function)
     }
 
-    /// Mutable variant of [`locate_with_selection_function`](#method.locate_with_selection_function).
-    pub fn locate_with_selection_function_mut<S: SelectionFunction<T>>(
+    /// Mutable variant of [`locate_with_selection_function_with_data`](#method.locate_with_selection_function_with_data).
+    pub fn locate_with_selection_function_with_data_mut<D, S: SelectionFunctionWithData<T, D>>(
         &mut self,
         selection_function: S,
-    ) -> impl Iterator<Item = &mut T> {
-        SelectionIteratorMut::new(&mut self.root, selection_function)
+    ) -> impl Iterator<Item = (&mut T, D)> {
+        SelectionWithDataIteratorMut::new(&mut self.root, selection_function)
     }
 
     /// Gets all possible intersecting objects of this and another tree.

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -415,7 +415,7 @@ where
         SelectionWithDataIteratorMut::new(&mut self.root, selection_function)
     }
 
-    /// Gets all possible intersecting objects of this and another tree.
+    /// Returns all possible intersecting objects of this and another tree.
     ///
     /// This will return all objects whose _envelopes_ intersect. No geometric intersection
     /// checking is performed.


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This is useful for things like ray intersections, where you want to return the time of impact in order to find the closest object.