### PR TITLE
Added LineWithData and RectangleWithData

### DIFF
--- a/rstar/src/primitives/line_with_data.rs
+++ b/rstar/src/primitives/line_with_data.rs
@@ -1,0 +1,145 @@
+use crate::aabb::AABB;
+use crate::envelope::Envelope;
+use crate::object::PointDistance;
+use crate::object::RTreeObject;
+use crate::point::{Point, PointExt};
+use num_traits::{One, Zero};
+
+/// A line defined by a start and and end point with associated data.
+///
+/// This struct can be inserted directly into an r-tree.
+/// # Type parameters
+/// `T`: The line's data type.
+/// `P`: The line's [Point] type.
+///
+/// # Example
+/// ```
+/// use rstar::primitives::LineWithData;
+/// use rstar::{RTree, RTreeObject};
+///
+/// let line_1 = LineWithData::new(1usize, [0.0, 0.0], [1.0, 1.0]);
+/// let line_2 = LineWithData::new(2usize, [0.0, 0.0], [-1.0, 1.0]);
+/// let tree = RTree::bulk_load(vec![line_1, line_2]);
+///
+/// assert!(tree.contains(&line_1));
+/// ```
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct LineWithData<T, P>
+where
+    P: Point,
+{
+    /// The line's data.
+    pub data: T,
+    /// The line's start point.
+    pub from: P,
+    /// The line's end point.
+    pub to: P,
+}
+
+impl<T, P> LineWithData<T, P>
+where
+    P: Point,
+{
+    /// Creates a new line between two points.
+    pub fn new(data: T, from: P, to: P) -> Self {
+        LineWithData { data, from, to }
+    }
+}
+
+impl<T, P> RTreeObject for LineWithData<T, P>
+where
+    P: Point,
+{
+    type Envelope = AABB<P>;
+
+    fn envelope(&self) -> Self::Envelope {
+        AABB::from_corners(self.from, self.to)
+    }
+}
+
+impl<T, P> LineWithData<T, P>
+where
+    P: Point,
+{
+    /// Returns the squared length of this line.
+    ///
+    /// # Example
+    /// ```
+    /// use rstar::primitives::Line;
+    ///
+    /// let line = Line::new([3, 3], [7, 6]);
+    /// assert_eq!(line.length_2(), 25);
+    /// ```
+    pub fn length_2(&self) -> P::Scalar {
+        self.from.sub(&self.to).length_2()
+    }
+
+    fn project_point(&self, query_point: &P) -> P::Scalar {
+        let (ref p1, ref p2) = (self.from, self.to);
+        let dir = p2.sub(p1);
+        query_point.sub(p1).dot(&dir) / dir.length_2()
+    }
+
+    /// Returns the nearest point on this line relative to a given point.
+    ///
+    /// # Example
+    /// ```
+    /// use rstar::primitives::Line;
+    ///
+    /// let line = Line::new([0.0, 0.0], [1., 1.]);
+    /// assert_eq!(line.nearest_point(&[0.0, 0.0]), [0.0, 0.0]);
+    /// assert_eq!(line.nearest_point(&[1.0, 0.0]), [0.5, 0.5]);
+    /// assert_eq!(line.nearest_point(&[10., 12.]), [1.0, 1.0]);
+    /// ```
+    pub fn nearest_point(&self, query_point: &P) -> P {
+        let (p1, p2) = (self.from, self.to);
+        let dir = p2.sub(&p1);
+        let s = self.project_point(query_point);
+        if P::Scalar::zero() < s && s < One::one() {
+            p1.add(&dir.mul(s))
+        } else if s <= P::Scalar::zero() {
+            p1
+        } else {
+            p2
+        }
+    }
+}
+
+impl<T, P> PointDistance for LineWithData<T, P>
+where
+    P: Point,
+{
+    fn distance_2(
+        &self,
+        point: &<Self::Envelope as Envelope>::Point,
+    ) -> <<Self::Envelope as Envelope>::Point as Point>::Scalar {
+        self.nearest_point(point).sub(point).length_2()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::LineWithData;
+    use crate::object::PointDistance;
+    use approx::*;
+
+    #[test]
+    fn edge_distance() {
+        let edge = LineWithData::new(1usize, [0.5, 0.5], [0.5, 2.0]);
+
+        assert_abs_diff_eq!(edge.distance_2(&[0.5, 0.5]), 0.0);
+        assert_abs_diff_eq!(edge.distance_2(&[0.0, 0.5]), 0.5 * 0.5);
+        assert_abs_diff_eq!(edge.distance_2(&[0.5, 1.0]), 0.0);
+        assert_abs_diff_eq!(edge.distance_2(&[0.0, 0.0]), 0.5);
+        assert_abs_diff_eq!(edge.distance_2(&[0.0, 1.0]), 0.5 * 0.5);
+        assert_abs_diff_eq!(edge.distance_2(&[1.0, 1.0]), 0.5 * 0.5);
+        assert_abs_diff_eq!(edge.distance_2(&[1.0, 3.0]), 0.5 * 0.5 + 1.0);
+    }
+
+    #[test]
+    fn length_2() {
+        let line = LineWithData::new(1usize, [1, -1], [5, 5]);
+        assert_eq!(line.length_2(), 16 + 36);
+    }
+}

--- a/rstar/src/primitives/mod.rs
+++ b/rstar/src/primitives/mod.rs
@@ -1,9 +1,13 @@
 //! Contains primitives ready for insertion into an r-tree.
 
 mod line;
+mod line_with_data;
 mod point_with_data;
 mod rectangle;
+mod rectangle_with_data;
 
 pub use self::line::Line;
+pub use self::line_with_data::LineWithData;
 pub use self::point_with_data::PointWithData;
 pub use self::rectangle::Rectangle;
+pub use self::rectangle_with_data::RectangleWithData;

--- a/rstar/src/primitives/rectangle_with_data.rs
+++ b/rstar/src/primitives/rectangle_with_data.rs
@@ -1,0 +1,137 @@
+use crate::aabb::AABB;
+use crate::envelope::Envelope;
+use crate::object::{PointDistance, RTreeObject};
+use crate::point::{Point, PointExt};
+
+/// An n-dimensional rectangle defined by its two corners and with associated data.
+///
+/// This rectangle can be directly inserted into an r-tree.
+///
+/// *Note*: Despite being called rectangle, this struct can be used
+/// with more than two dimensions by using an appropriate point type.
+///
+/// # Type parameters
+/// `P`: The rectangle's [Point] type.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct RectangleWithData<T, P>
+where
+    P: Point,
+{
+    /// The rectangles's data.
+    pub data: T,
+    aabb: AABB<P>,
+}
+
+impl<T, P> RectangleWithData<T, P>
+where
+    P: Point,
+{
+    /// Creates a new rectangle defined by two corners.
+    pub fn from_corners(data: T, corner_1: P, corner_2: P) -> Self {
+        let aabb = AABB::from_corners(corner_1, corner_2);
+        RectangleWithData { data, aabb }
+    }
+
+    /// Creates a new rectangle defined by it's [axis aligned bounding box(AABB).
+    pub fn from_aabb(data: T, aabb: AABB<P>) -> Self {
+        RectangleWithData { data, aabb }
+    }
+
+    /// Returns the rectangle's lower corner.
+    ///
+    /// This is the point contained within the rectangle with the smallest coordinate value in each
+    /// dimension.
+    pub fn lower(&self) -> P {
+        self.aabb.lower()
+    }
+
+    /// Returns the rectangle's upper corner.
+    ///
+    /// This is the point contained within the AABB with the largest coordinate value in each
+    /// dimension.
+    pub fn upper(&self) -> P {
+        self.aabb.upper()
+    }
+}
+
+// impl<T, P> From<AABB<P>> for RectangleWithData<T, P>
+// where
+//     P: Point,
+// {
+//     fn from(data: T, aabb: AABB<P>) -> Self {
+//         Self::from_aabb(data, aabb)
+//     }
+// }
+
+impl<T, P> RTreeObject for RectangleWithData<T, P>
+where
+    P: Point,
+{
+    type Envelope = AABB<P>;
+
+    fn envelope(&self) -> Self::Envelope {
+        self.aabb
+    }
+}
+
+impl<T, P> RectangleWithData<T, P>
+where
+    P: Point,
+{
+    /// Returns the nearest point within this rectangle to a given point.
+    ///
+    /// If `query_point` is contained within this rectangle, `query_point` is returned.
+    pub fn nearest_point(&self, query_point: &P) -> P {
+        self.aabb.min_point(query_point)
+    }
+}
+
+impl<T, P> PointDistance for RectangleWithData<T, P>
+where
+    P: Point,
+{
+    fn distance_2(
+        &self,
+        point: &<Self::Envelope as Envelope>::Point,
+    ) -> <<Self::Envelope as Envelope>::Point as Point>::Scalar {
+        self.nearest_point(point).sub(point).length_2()
+    }
+
+    fn contains_point(&self, point: &<Self::Envelope as Envelope>::Point) -> bool {
+        self.aabb.contains_point(point)
+    }
+
+    fn distance_2_if_less_or_equal(
+        &self,
+        point: &<Self::Envelope as Envelope>::Point,
+        max_distance_2: <<Self::Envelope as Envelope>::Point as Point>::Scalar,
+    ) -> Option<<<Self::Envelope as Envelope>::Point as Point>::Scalar> {
+        let distance_2 = self.distance_2(point);
+        if distance_2 <= max_distance_2 {
+            Some(distance_2)
+        } else {
+            None
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::RectangleWithData;
+    use crate::object::PointDistance;
+    use approx::*;
+
+    #[test]
+    fn rectangle_distance() {
+        let rectangle = RectangleWithData::from_corners(1usize, [0.5, 0.5], [1.0, 2.0]);
+
+        assert_abs_diff_eq!(rectangle.distance_2(&[0.5, 0.5]), 0.0);
+        assert_abs_diff_eq!(rectangle.distance_2(&[0.0, 0.5]), 0.5 * 0.5);
+        assert_abs_diff_eq!(rectangle.distance_2(&[0.5, 1.0]), 0.0);
+        assert_abs_diff_eq!(rectangle.distance_2(&[0.0, 0.0]), 0.5);
+        assert_abs_diff_eq!(rectangle.distance_2(&[0.0, 1.0]), 0.5 * 0.5);
+        assert_abs_diff_eq!(rectangle.distance_2(&[1.0, 3.0]), 1.0);
+        assert_abs_diff_eq!(rectangle.distance_2(&[1.0, 1.0]), 0.0);
+    }
+}


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---
I have added a data variants of the Line and Rectangle primitives, in order to allow the association of attribute data.
