### PR TITLE
Add remove_in_envelope_intersecting

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+## Added
+- Add `RTree::drain_*` methods to remove and drain selected items. ([PR](https://github.com/georust/rstar/pull/77))
+
+## Changed
+- Expose all iterator types in `crate::iterators` module ([PR](https://github.com/georust/rstar/pull/77))
+
 # 0.9.1
 
 ## Added

--- a/rstar/src/algorithm/intersection_iterator.rs
+++ b/rstar/src/algorithm/intersection_iterator.rs
@@ -4,6 +4,10 @@ use crate::RTreeNode;
 use crate::RTreeNode::*;
 use crate::RTreeObject;
 
+#[cfg(doc)]
+use crate::RTree;
+
+/// Iterator returned by [`RTree::intersection_candidates_with_other_tree`].
 pub struct IntersectionIterator<'a, T, U = T>
 where
     T: RTreeObject,

--- a/rstar/src/algorithm/iterators.rs
+++ b/rstar/src/algorithm/iterators.rs
@@ -2,21 +2,41 @@ use crate::algorithm::selection_functions::*;
 use crate::node::{ParentNode, RTreeNode};
 use crate::object::RTreeObject;
 
+#[cfg(doc)]
+use crate::RTree;
+
 use smallvec::SmallVec;
 
+pub use super::removal::DrainIterator;
+pub use super::intersection_iterator::IntersectionIterator;
+
+/// Iterator returned by [`RTree::locate_all_at_point`].
 pub type LocateAllAtPoint<'a, T> = SelectionIterator<'a, T, SelectAtPointFunction<T>>;
+/// Iterator returned by [`RTree::locate_all_at_point_mut`].
 pub type LocateAllAtPointMut<'a, T> = SelectionIteratorMut<'a, T, SelectAtPointFunction<T>>;
+
+/// Iterator returned by [`RTree::locate_in_envelope`].
 pub type LocateInEnvelope<'a, T> = SelectionIterator<'a, T, SelectInEnvelopeFunction<T>>;
+/// Iterator returned by [`RTree::locate_in_envelope_mut`].
 pub type LocateInEnvelopeMut<'a, T> = SelectionIteratorMut<'a, T, SelectInEnvelopeFunction<T>>;
+
+/// Iterator returned by [`RTree::locate_in_envelope_intersecting`].
 pub type LocateInEnvelopeIntersecting<'a, T> =
     SelectionIterator<'a, T, SelectInEnvelopeFuncIntersecting<T>>;
+/// Iterator returned by [`RTree::locate_in_envelope_intersecting_mut`].
 pub type LocateInEnvelopeIntersectingMut<'a, T> =
     SelectionIteratorMut<'a, T, SelectInEnvelopeFuncIntersecting<T>>;
+
+/// Iterator returned by [`RTree::iter`].
 pub type RTreeIterator<'a, T> = SelectionIterator<'a, T, SelectAllFunc>;
+/// Iterator returned by [`RTree::iter_mut`].
 pub type RTreeIteratorMut<'a, T> = SelectionIteratorMut<'a, T, SelectAllFunc>;
+
+/// Iterator returned by [`RTree::locate_within_distance`].
 pub type LocateWithinDistanceIterator<'a, T> =
     SelectionIterator<'a, T, SelectWithinDistanceFunction<T>>;
 
+/// Iterator returned by `RTree::locate_*` methods.
 pub struct SelectionIterator<'a, T, Func>
 where
     T: RTreeObject + 'a,
@@ -31,7 +51,7 @@ where
     T: RTreeObject,
     Func: SelectionFunction<T>,
 {
-    pub fn new(root: &'a ParentNode<T>, func: Func) -> Self {
+    pub(crate) fn new(root: &'a ParentNode<T>, func: Func) -> Self {
         let current_nodes = if func.should_unpack_parent(&root.envelope()) {
             root.children.iter().collect()
         } else {
@@ -71,6 +91,7 @@ where
     }
 }
 
+/// Iterator type returned by `RTree::locate_*_mut` methods.
 pub struct SelectionIteratorMut<'a, T, Func>
 where
     T: RTreeObject + 'a,
@@ -85,7 +106,7 @@ where
     T: RTreeObject,
     Func: SelectionFunction<T>,
 {
-    pub fn new(root: &'a mut ParentNode<T>, func: Func) -> Self {
+    pub(crate) fn new(root: &'a mut ParentNode<T>, func: Func) -> Self {
         let current_nodes = if func.should_unpack_parent(&root.envelope()) {
             root.children.iter_mut().collect()
         } else {

--- a/rstar/src/algorithm/mod.rs
+++ b/rstar/src/algorithm/mod.rs
@@ -1,5 +1,6 @@
 pub mod bulk_load;
 pub mod intersection_iterator;
+/// Iterator types
 pub mod iterators;
 pub mod nearest_neighbor;
 pub mod removal;

--- a/rstar/src/algorithm/removal.rs
+++ b/rstar/src/algorithm/removal.rs
@@ -18,7 +18,7 @@ where
     Params: RTreeParams,
     R: SelectionFunction<T>,
 {
-    remove_recursive::<_, Params, _>(node, removal_function, false).pop()
+    remove_recursive::<_, Params, _>(node, removal_function, true).pop()
 }
 
 pub fn remove_all<T, Params, R>(node: &mut ParentNode<T>, removal_function: &R) -> Vec<T>
@@ -27,13 +27,13 @@ where
     Params: RTreeParams,
     R: SelectionFunction<T>,
 {
-    remove_recursive::<_, Params, _>(node, removal_function, true)
+    remove_recursive::<_, Params, _>(node, removal_function, false)
 }
 
 fn remove_recursive<T, Params, R>(
     node: &mut ParentNode<T>,
     removal_function: &R,
-    all_matches: bool,
+    remove_only_first: bool,
 ) -> Vec<T>
 where
     T: RTreeObject,
@@ -50,12 +50,14 @@ where
                     result.append(&mut remove_recursive::<_, Params, _>(
                         data,
                         removal_function,
-                        all_matches,
+                        remove_only_first,
                     ));
-                    if !result.is_empty() && data.children.is_empty() {
+                    if !result.is_empty() {
                         // Mark child for removal if it has become empty
-                        node.children.remove(i);
-                        if !all_matches {
+                        if data.children.is_empty() {
+                            node.children.remove(i);
+                        }
+                        if remove_only_first {
                             break;
                         }
                     } else {
@@ -71,7 +73,7 @@ where
                         } else {
                             unreachable!("This is a bug.");
                         }
-                        if !all_matches {
+                        if remove_only_first {
                             break;
                         }
                     } else {

--- a/rstar/src/algorithm/removal.rs
+++ b/rstar/src/algorithm/removal.rs
@@ -1,7 +1,10 @@
+use std::mem::replace;
+
 use crate::algorithm::selection_functions::SelectionFunction;
 use crate::node::{ParentNode, RTreeNode};
 use crate::object::RTreeObject;
 use crate::params::RTreeParams;
+use crate::RTree;
 
 /// Default removal strategy to remove elements from an r-tree. A [RemovalFunction]
 /// specifies which elements shall be removed.
@@ -90,12 +93,174 @@ where
     result
 }
 
+pub(crate) struct DrainIterator<'a, T, R, Params>
+where
+    T: RTreeObject,
+    Params: RTreeParams,
+    R: SelectionFunction<T>,
+{
+    node_stack: Vec<(ParentNode<T>, usize, usize)>,
+    removal_function: R,
+    rtree: &'a mut RTree<T, Params>,
+    original_size: usize,
+}
+
+impl<'a, T, R, Params> DrainIterator<'a, T, R, Params>
+where
+    T: RTreeObject,
+    Params: RTreeParams,
+    R: SelectionFunction<T>,
+{
+    pub(crate) fn new(rtree: &'a mut RTree<T, Params>, removal_function: R) -> Self {
+        // We replace with a brand new RTree in case the iterator is
+        // `mem::forgot`ten.
+        let RTree { root, size, .. } = replace(rtree, RTree::new_with_params());
+
+        DrainIterator {
+            node_stack: vec![(root, 0, 0)],
+            original_size: size,
+            removal_function, rtree,
+        }
+    }
+
+    fn pop_node(&mut self, increment_idx: bool) -> Option<(ParentNode<T>, usize)> {
+        debug_assert!(!self.node_stack.is_empty());
+
+        let (mut node, _, num_removed) = self.node_stack.pop().unwrap();
+
+        // We only compute envelope for the current node as the parent
+        // is taken care of when it is popped.
+
+        // TODO: May be make this a method on `ParentNode`
+        if num_removed > 0 {
+            node.envelope = crate::node::envelope_for_children(&node.children);
+        }
+
+        // If there is no parent, this is the new root node to set back in the rtree
+        // O/w, get the new top in stack
+        let (parent_node, parent_idx, parent_removed) = match self.node_stack.last_mut() {
+            Some(pn) => (&mut pn.0, &mut pn.1, &mut pn.2),
+            None => return Some((node, num_removed)),
+        };
+
+        // Update the remove count on parent
+        *parent_removed += num_removed;
+
+        // If the node has no children, we don't need to add it back to the parent
+        if node.children.is_empty() { return None; }
+
+        // Put the child back (but re-arranged)
+        parent_node.children.push(RTreeNode::Parent(node));
+
+        // Swap it with the current item and increment idx.
+
+        // A minor optimization is to avoid the swap in the destructor,
+        // where we aren't going to be iterating any more.
+        if !increment_idx { return None; }
+
+        // Note that during iteration, parent_idx may be equal to
+        // (previous) children.len(), but this is okay as the swap will be
+        // a no-op.
+        let parent_len = parent_node.children.len();
+        parent_node.children.swap(*parent_idx, parent_len - 1);
+        *parent_idx += 1;
+
+        None
+    }
+}
+
+impl<'a, T, R, Params> Iterator for DrainIterator<'a, T, R, Params>
+where
+    T: RTreeObject,
+    Params: RTreeParams,
+    R: SelectionFunction<T>,
+{
+    type Item = T;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let (node, idx, remove_count) = match self.node_stack.last_mut() {
+            Some(node) => (&mut node.0, &mut node.1, &mut node.2),
+            None => return None,
+        };
+
+        if *idx > 0 || self.removal_function.should_unpack_parent(&node.envelope) {
+            while *idx < node.children.len() {
+                match &mut node.children[*idx] {
+                    RTreeNode::Parent(_) => {
+                        // Swap node with last, remove and return the value.
+                        // No need to increment idx as something else has replaced it;
+                        // or idx == new len, and we'll handle it in the next iteration.
+                        let child = match node.children.swap_remove(*idx) {
+                            RTreeNode::Leaf(_) => unreachable!("DrainIterator bug!"),
+                            RTreeNode::Parent(node) => node,
+                        };
+                        self.node_stack.push((child, 0, 0));
+                        return self.next();
+                    }
+                    RTreeNode::Leaf(ref leaf) => {
+                        if self.removal_function.should_unpack_leaf(leaf) {
+                            // Swap node with last, remove and return the value.
+                            // No need to increment idx as something else has replaced it;
+                            // or idx == new len, and we'll handle it in the next iteration.
+                            *remove_count += 1;
+                            return match node.children.swap_remove(*idx) {
+                                RTreeNode::Leaf(data) => Some(data),
+                                _ => unreachable!("RemovalIterator bug!"),
+                            };
+                        }
+                        *idx += 1;
+                    }
+                }
+            }
+        }
+
+        if let Some((new_root, total_removed)) = self.pop_node(true) {
+            // This happens if we are done with the iteration.
+            // Set the root back in rtree and return None
+            self.rtree.root = new_root;
+            self.rtree.size = self.original_size - total_removed;
+            return None;
+        }
+
+        // TODO: fix tail recursion (it's only log-n depth though)
+        self.next()
+    }
+}
+
+impl<'a, T, R, Params> Drop for DrainIterator<'a, T, R, Params>
+where
+    T: RTreeObject,
+    Params: RTreeParams,
+    R: SelectionFunction<T>,
+{
+    fn drop(&mut self) {
+        // Re-assemble back the original rtree and update envelope as we
+        // re-assemble.
+        if self.node_stack.is_empty() {
+            // The iteration handled everything, nothing to do.
+            return;
+        }
+
+        loop {
+            debug_assert!(!self.node_stack.is_empty());
+            if let Some((new_root, total_removed)) = self.pop_node(false) {
+                self.rtree.root = new_root;
+                self.rtree.size = self.original_size - total_removed;
+                break;
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod test {
+    use crate::algorithm::selection_functions::{SelectAllFunc, SelectInEnvelopeFuncIntersecting};
     use crate::point::PointExt;
     use crate::primitives::Line;
     use crate::test_utilities::{create_random_points, create_random_rectangles, SEED_1, SEED_2};
-    use crate::RTree;
+    use crate::{AABB, RTree};
+
+    use super::*;
 
     #[test]
     fn test_remove_and_insert() {
@@ -173,5 +338,39 @@ mod test {
             assert!(tree.remove(edge).is_none());
             assert_eq!(size_before_removal - 1, tree.size());
         }
+    }
+
+    #[test]
+    fn test_drain_iterator() {
+        const SIZE: usize = 1000;
+        let points = create_random_points(SIZE, SEED_1);
+        let mut tree = RTree::bulk_load(points.clone());
+
+        let drain_count = DrainIterator::new(&mut tree, SelectAllFunc).take(250).count();
+        assert_eq!(drain_count, 250);
+        assert_eq!(tree.size(), 750);
+
+        let drain_count = DrainIterator::new(&mut tree, SelectAllFunc).count();
+        assert_eq!(drain_count, 750);
+        assert_eq!(tree.size(), 0);
+
+        let points = create_random_points(1000, SEED_1);
+        let mut tree = RTree::bulk_load(points.clone());
+
+        // The total for this is 406 (for SEED_1)
+        let env = AABB::from_corners([-2., -0.6], [0.5, 0.85]);
+
+        let sel = SelectInEnvelopeFuncIntersecting::new(env);
+        let drain_count = DrainIterator::new(&mut tree, sel).take(80).count();
+        assert_eq!(drain_count, 80);
+
+        let sel = SelectInEnvelopeFuncIntersecting::new(env);
+        let drain_count = DrainIterator::new(&mut tree, sel).count();
+        assert_eq!(drain_count, 326);
+
+        let sel = SelectInEnvelopeFuncIntersecting::new(env);
+        let sel_count = tree.locate_with_selection_function(sel).count();
+        assert_eq!(sel_count, 0);
+        assert_eq!(tree.size(), 1000 - 80 - 326);
     }
 }

--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -44,3 +44,5 @@ pub use crate::object::{PointDistance, RTreeObject};
 pub use crate::params::{DefaultParams, InsertionStrategy, RTreeParams};
 pub use crate::point::{Point, RTreeNum};
 pub use crate::rtree::RTree;
+
+pub use crate::algorithm::iterators;

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -447,6 +447,22 @@ where
         }
         result
     }
+
+    /// Removes all elements that are selected by a given [`SelectionFunction`].
+    pub fn remove_all_with_selection_function<F>(&mut self, function: F) -> Vec<T>
+    where
+        F: SelectionFunction<T>,
+    {
+        let result = removal::remove_all::<_, Params, _>(&mut self.root, &function);
+        self.size -= result.len();
+        result
+    }
+
+    /// Remove all elements intersecting an envelope.
+    pub fn remove_in_envelope_intersecting(&mut self, envelope: &T::Envelope) -> Vec<T> {
+        let selection_function = SelectInEnvelopeFuncIntersecting::new(*envelope);
+        self.remove_all_with_selection_function(selection_function)
+    }
 }
 
 impl<T, Params> RTree<T, Params>

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -315,6 +315,12 @@ where
         LocateInEnvelopeMut::new(&mut self.root, SelectInEnvelopeFunction::new(*envelope))
     }
 
+    /// Draining variant of [locate_in_envelope](#method.locate_in_envelope).
+    pub fn drain_in_envelope(&mut self, envelope: T::Envelope) -> DrainIterator<T, SelectInEnvelopeFunction<T>, Params> {
+        let sel = SelectInEnvelopeFunction::new(envelope);
+        self.drain_with_selection_function(sel)
+    }
+
     /// Returns all elements whose envelope intersects a given envelope.
     ///
     /// Any element fully contained within an envelope is also returned by this method. Two

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -667,6 +667,16 @@ where
         LocateWithinDistanceIterator::new(self.root(), selection_function)
     }
 
+    /// Remove all elements within a given distance.
+    pub fn remove_within_distance(
+        &mut self,
+        query_point: <T::Envelope as Envelope>::Point,
+        max_squared_radius: <<T::Envelope as Envelope>::Point as Point>::Scalar,
+    ) -> Vec<T> {
+        let selection_function = SelectWithinDistanceFunction::new(query_point, max_squared_radius);
+        self.remove_all_with_selection_function(selection_function)
+    }
+
     /// Returns all elements of the tree sorted by their distance to a given point.
     ///
     /// # Runtime

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -143,8 +143,8 @@ where
     Params: RTreeParams,
     T: RTreeObject,
 {
-    root: ParentNode<T>,
-    size: usize,
+    pub(crate) root: ParentNode<T>,
+    pub(crate) size: usize,
     _params: ::std::marker::PhantomData<Params>,
 }
 
@@ -441,11 +441,7 @@ where
     where
         F: SelectionFunction<T>,
     {
-        let result = removal::remove::<_, Params, _>(&mut self.root, &function);
-        if result.is_some() {
-            self.size -= 1;
-        }
-        result
+        removal::DrainIterator::new(self, function).take(1).last()
     }
 
     /// Removes all elements that are selected by a given [`SelectionFunction`].


### PR DESCRIPTION
This pull request implements a remove function that can remove all selected elements. It also adds a convenience function to `RTree` to remove all elements inside a given envelope.

The tests pass but I expect that I have to do some cleanup, extend the API and or write some additional tests.

Related #76 

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.


