### PR TITLE
enable compilation for no_std

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - rstar
+      - no_std
     steps:
       - name: Mark the job as a success
         if: success()
@@ -40,3 +41,24 @@ jobs:
       - run: cargo build-all-features
       - run: cargo test-all-features
       - run: cargo build -p rstar-benches
+
+  no_std:
+    name: rstar no_std test
+    runs-on: ubuntu-latest
+    env: 
+      NO_STD_TARGET: aarch64-unknown-none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          target: ${{env.NO_STD_TARGET}}
+          toolchain: stable
+          override: true
+      - name: Run cargo build for ${{env.NO_STD_TARGET}}
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --package rstar --target ${{env.NO_STD_TARGET}}

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -2,6 +2,8 @@
 ## Changed
 - Removed dependency on `pdqselect` ([PR](https://github.com/georust/rstar/pull/85))
 - New **minimal supported rust version (MSRV): 1.49.0**
+- Replace all usages of `std` with `core` & `alloc` to make `rstar` fit for
+  `no_std`. ([PR](https://github.com/georust/rstar/pull/83))
 
 # 0.9.2
 - Add `RTree::drain_*` methods to remove and drain selected items. ([PR](https://github.com/georust/rstar/pull/77))

--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -16,8 +16,8 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 heapless = "0.6"
-num-traits = "0.2"
-serde = { version = "1.0", optional = true, features = ["derive"] }
+num-traits = { version = "0.2", default-features = false, features = ["libm"] }
+serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
 smallvec = "1.6"
 
 [features]

--- a/rstar/README.md
+++ b/rstar/README.md
@@ -20,6 +20,7 @@ A flexible, n-dimensional [r*-tree](https://en.wikipedia.org/wiki/R*_tree) imple
    - Rectangles
  - Small number of dependencies
  - Serde support with the `serde` feature
+ - `no_std` compatible (but requires [`alloc`](https://doc.rust-lang.org/alloc/))
 
 # Benchmarks
 All benchmarks are performed on a i7-8550U CPU @ 1.80Ghz and with uniformly distributed points. The underlying point type is `[f64; 2]`.

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -156,7 +156,7 @@ where
             max = max * max;
             min = min * min;
             if max < min {
-                std::mem::swap(&mut min, &mut max);
+                core::mem::swap(&mut min, &mut max);
             }
 
             let diff = max - min;

--- a/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
+++ b/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
@@ -4,6 +4,11 @@ use crate::object::RTreeObject;
 use crate::params::RTreeParams;
 use crate::point::Point;
 
+use alloc::{vec, vec::Vec};
+
+#[allow(unused_imports)] // Import is required when building without std
+use num_traits::Float;
+
 use super::cluster_group_iterator::{calculate_number_of_clusters_on_axis, ClusterGroupIterator};
 
 fn bulk_load_recursive<T, Params>(elements: Vec<T>, depth: usize) -> ParentNode<T>
@@ -47,7 +52,7 @@ struct PartitioningTask<T: RTreeObject, Params: RTreeParams> {
     work_queue: Vec<PartitioningState<T>>,
     depth: usize,
     number_of_clusters_on_axis: usize,
-    _params: std::marker::PhantomData<Params>,
+    _params: core::marker::PhantomData<Params>,
 }
 
 impl<T: RTreeObject, Params: RTreeParams> Iterator for PartitioningTask<T, Params> {

--- a/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
+++ b/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
@@ -1,5 +1,10 @@
 use crate::{Envelope, Point, RTreeObject, RTreeParams};
 
+use alloc::{vec, vec::Vec};
+
+#[allow(unused_imports)] // Import is required when building without std
+use num_traits::Float;
+
 /// Partitions elements into groups of clusters along a specific axis.
 pub struct ClusterGroupIterator<T: RTreeObject> {
     remaining: Vec<T>,
@@ -28,12 +33,14 @@ impl<T: RTreeObject> Iterator for ClusterGroupIterator<T> {
     fn next(&mut self) -> Option<Self::Item> {
         match self.remaining.len() {
             0 => None,
-            len if len <= self.slab_size => ::std::mem::replace(&mut self.remaining, vec![]).into(),
+            len if len <= self.slab_size => {
+                ::core::mem::replace(&mut self.remaining, vec![]).into()
+            }
             _ => {
                 let slab_axis = self.cluster_dimension;
                 T::Envelope::partition_envelopes(slab_axis, &mut self.remaining, self.slab_size);
                 let off_split = self.remaining.split_off(self.slab_size);
-                ::std::mem::replace(&mut self.remaining, off_split).into()
+                ::core::mem::replace(&mut self.remaining, off_split).into()
             }
         }
     }

--- a/rstar/src/algorithm/intersection_iterator.rs
+++ b/rstar/src/algorithm/intersection_iterator.rs
@@ -4,6 +4,8 @@ use crate::RTreeNode;
 use crate::RTreeNode::*;
 use crate::RTreeObject;
 
+use alloc::vec::Vec;
+
 #[cfg(doc)]
 use crate::RTree;
 

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -1,9 +1,10 @@
 use crate::node::{ParentNode, RTreeNode};
 use crate::point::{min_inline, Point};
 use crate::{Envelope, PointDistance, RTreeObject};
+
+use alloc::{collections::BinaryHeap, vec, vec::Vec};
 use heapless::binary_heap as static_heap;
 use num_traits::Bounded;
-use std::collections::binary_heap::BinaryHeap;
 
 struct RTreeNodeDistanceWrapper<'a, T>
 where
@@ -26,7 +27,7 @@ impl<'a, T> PartialOrd for RTreeNodeDistanceWrapper<'a, T>
 where
     T: PointDistance,
 {
-    fn partial_cmp(&self, other: &Self) -> Option<::std::cmp::Ordering> {
+    fn partial_cmp(&self, other: &Self) -> Option<::core::cmp::Ordering> {
         // Inverse comparison creates a min heap
         other.distance.partial_cmp(&self.distance)
     }
@@ -38,7 +39,7 @@ impl<'a, T> Ord for RTreeNodeDistanceWrapper<'a, T>
 where
     T: PointDistance,
 {
-    fn cmp(&self, other: &Self) -> ::std::cmp::Ordering {
+    fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
         self.partial_cmp(other).unwrap()
     }
 }
@@ -293,7 +294,7 @@ mod test {
         let sample_points = create_random_points(100, SEED_2);
         for sample_point in &sample_points {
             let mut nearest = None;
-            let mut closest_dist = ::std::f64::INFINITY;
+            let mut closest_dist = ::core::f64::INFINITY;
             for point in &points {
                 let delta = [point[0] - sample_point[0], point[1] - sample_point[1]];
                 let new_dist = delta[0] * delta[0] + delta[1] * delta[1];

--- a/rstar/src/algorithm/removal.rs
+++ b/rstar/src/algorithm/removal.rs
@@ -1,10 +1,15 @@
-use std::mem::replace;
+use core::mem::replace;
 
 use crate::algorithm::selection_functions::SelectionFunction;
 use crate::node::{ParentNode, RTreeNode};
 use crate::object::RTreeObject;
 use crate::params::RTreeParams;
 use crate::{Envelope, RTree};
+
+use alloc::{vec, vec::Vec};
+
+#[allow(unused_imports)] // Import is required when building without std
+use num_traits::Float;
 
 /// Iterator returned by `RTree::drain_*` methods.
 ///

--- a/rstar/src/algorithm/rstar.rs
+++ b/rstar/src/algorithm/rstar.rs
@@ -4,6 +4,8 @@ use crate::object::RTreeObject;
 use crate::params::{InsertionStrategy, RTreeParams};
 use crate::point::{Point, PointExt};
 use crate::rtree::RTree;
+
+use alloc::vec::Vec;
 use num_traits::{Bounded, Zero};
 
 /// Inserts points according to the r-star heuristic.
@@ -55,7 +57,7 @@ impl InsertionStrategy for RStarInsertionStrategy {
                 PerformSplit(node) => {
                     // The root node was split, create a new root and increase height
                     let new_root = ParentNode::new_root::<Params>();
-                    let old_root = ::std::mem::replace(tree.root_mut(), new_root);
+                    let old_root = ::core::mem::replace(tree.root_mut(), new_root);
                     let new_envelope = old_root.envelope.merged(&node.envelope());
                     let root = tree.root_mut();
                     root.envelope = new_envelope;

--- a/rstar/src/algorithm/selection_functions.rs
+++ b/rstar/src/algorithm/selection_functions.rs
@@ -236,6 +236,6 @@ where
     }
 
     fn should_unpack_leaf(&self, leaf: &T) -> bool {
-        std::ptr::eq(self.element_address, leaf)
+        core::ptr::eq(self.element_address, leaf)
     }
 }

--- a/rstar/src/envelope.rs
+++ b/rstar/src/envelope.rs
@@ -6,7 +6,7 @@ use crate::{Point, RTreeObject};
 /// e.g. how they can be merged or intersected.
 /// This trait is not meant to be implemented by the user. Currently, only one implementation
 /// exists ([crate::AABB]) and should be used.
-pub trait Envelope: Clone + Copy + PartialEq + ::std::fmt::Debug {
+pub trait Envelope: Clone + Copy + PartialEq + ::core::fmt::Debug {
     /// The envelope's point type.
     type Point: Point;
 

--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -21,6 +21,9 @@
 //!
 #![deny(missing_docs)]
 #![forbid(unsafe_code)]
+#![cfg_attr(not(test), no_std)]
+
+extern crate alloc;
 
 mod aabb;
 mod algorithm;

--- a/rstar/src/node.rs
+++ b/rstar/src/node.rs
@@ -2,6 +2,8 @@ use crate::envelope::Envelope;
 use crate::object::RTreeObject;
 use crate::params::RTreeParams;
 
+use alloc::vec::Vec;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -1,5 +1,5 @@
 use num_traits::{Bounded, Num, Signed, Zero};
-use std::fmt::Debug;
+use core::fmt::Debug;
 
 /// Defines a number type that is compatible with rstar.
 ///
@@ -64,32 +64,32 @@ use std::fmt::Debug;
 /// #   fn one() -> Self { unimplemented!() }
 /// # }
 /// #
-/// # impl std::ops::Mul for MyFancyNumberType {
+/// # impl core::ops::Mul for MyFancyNumberType {
 /// #   type Output = Self;
 /// #   fn mul(self, rhs: Self) -> Self { unimplemented!() }
 /// # }
 /// #
-/// # impl std::ops::Add for MyFancyNumberType {
+/// # impl core::ops::Add for MyFancyNumberType {
 /// #   type Output = Self;
 /// #   fn add(self, rhs: Self) -> Self { unimplemented!() }
 /// # }
 /// #
-/// # impl std::ops::Sub for MyFancyNumberType {
+/// # impl core::ops::Sub for MyFancyNumberType {
 /// #   type Output = Self;
 /// #   fn sub(self, rhs: Self) -> Self { unimplemented!() }
 /// # }
 /// #
-/// # impl std::ops::Div for MyFancyNumberType {
+/// # impl core::ops::Div for MyFancyNumberType {
 /// #   type Output = Self;
 /// #   fn div(self, rhs: Self) -> Self { unimplemented!() }
 /// # }
 /// #
-/// # impl std::ops::Rem for MyFancyNumberType {
+/// # impl core::ops::Rem for MyFancyNumberType {
 /// #   type Output = Self;
 /// #   fn rem(self, rhs: Self) -> Self { unimplemented!() }
 /// # }
 /// #
-/// # impl std::ops::Neg for MyFancyNumberType {
+/// # impl core::ops::Neg for MyFancyNumberType {
 /// #   type Output = Self;
 /// #   fn neg(self) -> Self { unimplemented!() }
 /// # }

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -13,6 +13,8 @@ use crate::object::{PointDistance, RTreeObject};
 use crate::params::{verify_parameters, DefaultParams, InsertionStrategy, RTreeParams};
 use crate::Point;
 
+use alloc::vec::Vec;
+
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -148,33 +150,33 @@ where
 {
     root: ParentNode<T>,
     size: usize,
-    _params: ::std::marker::PhantomData<Params>,
+    _params: ::core::marker::PhantomData<Params>,
 }
 
 struct DebugHelper<'a, T, Params>
 where
-    T: RTreeObject + ::std::fmt::Debug + 'a,
+    T: RTreeObject + ::core::fmt::Debug + 'a,
     Params: RTreeParams + 'a,
 {
     rtree: &'a RTree<T, Params>,
 }
 
-impl<'a, T, Params> ::std::fmt::Debug for DebugHelper<'a, T, Params>
+impl<'a, T, Params> ::core::fmt::Debug for DebugHelper<'a, T, Params>
 where
-    T: RTreeObject + ::std::fmt::Debug,
+    T: RTreeObject + ::core::fmt::Debug,
     Params: RTreeParams,
 {
-    fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         formatter.debug_set().entries(self.rtree.iter()).finish()
     }
 }
 
-impl<T, Params> ::std::fmt::Debug for RTree<T, Params>
+impl<T, Params> ::core::fmt::Debug for RTree<T, Params>
 where
     Params: RTreeParams,
-    T: RTreeObject + ::std::fmt::Debug,
+    T: RTreeObject + ::core::fmt::Debug,
 {
-    fn fmt(&self, formatter: &mut ::std::fmt::Formatter) -> ::std::fmt::Result {
+    fn fmt(&self, formatter: &mut ::core::fmt::Formatter) -> ::core::fmt::Result {
         formatter
             .debug_struct("RTree")
             .field("size", &self.size)


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This is basically a redo of https://github.com/georust/rstar/pull/27 . ~~I'm not sure whether we should have the `alloc` feature or not. In the best case, we would haven an rstar implementation which can work without alloc - but my understanding of this implementation is rather limited. Currently, one needs to either pick the `std` or the alloc feature, picking none of them results in compilation failure. Maybe we can resort to `heapless::Vec` in the future, but this for sure requires further modifications.~~ This does not include any new features. Compilation is supported for both `std` and `no_std`, but the latter requires `alloc`. For validation, I did this:

+ `cargo build --target thumbv7em-none-eabihf`
+ `cargo build`
+ `cargo build --release`
+ `cargo test`
+ `cargo test --release`