### PR TITLE
Remove pdqselect dependency

### DIFF
--- a/rstar-benches/Cargo.toml
+++ b/rstar-benches/Cargo.toml
@@ -7,7 +7,6 @@ authors = ["Stefan Altmayer <stoeoef@gmail.com>", "The Georust Developers <mods@
 rand = "0.7"
 rand_hc = "0.2"
 criterion = { version = "0.3.4", features = ["html_reports"] }
-spade = "1.8"
 rstar = { path = "../rstar" }
 
 [[bench]]

--- a/rstar-benches/benches/benchmarks.rs
+++ b/rstar-benches/benches/benchmarks.rs
@@ -4,7 +4,6 @@ extern crate criterion;
 extern crate rand;
 extern crate rand_hc;
 extern crate rstar;
-extern crate spade;
 
 use rand::{Rng, SeedableRng};
 use rand_hc::Hc128Rng;
@@ -39,16 +38,7 @@ fn bulk_load_baseline(c: &mut Criterion) {
 
 fn bulk_load_comparison(c: &mut Criterion) {
     let mut group = c.benchmark_group("rstar and spade benchmarks");
-    group.bench_function("rstar bench", |b| {
-        let points: Vec<_> = create_random_points(DEFAULT_BENCHMARK_TREE_SIZE, SEED_1);
-        b.iter(|| RTree::<_, Params>::bulk_load_with_params(points.clone()));
-    });
-    group.bench_function("spade bench", |b| {
-        let points: Vec<_> = create_random_points(DEFAULT_BENCHMARK_TREE_SIZE, SEED_1);
-        b.iter(move || {
-            spade::rtree::RTree::bulk_load(points.clone());
-        });
-    });
+
     group.bench_function("rstar sequential", |b| {
         let points: Vec<_> = create_random_points(DEFAULT_BENCHMARK_TREE_SIZE, SEED_1);
         b.iter(move || {

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Unreleased
+## Changed
+- Removed dependency on `pdqselect` ([PR](https://github.com/georust/rstar/pull/85))
+- New **minimal supported rust version (MSRV): 1.49.0**
 
 # 0.9.2
 - Add `RTree::drain_*` methods to remove and drain selected items. ([PR](https://github.com/georust/rstar/pull/77))

--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -17,7 +17,6 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 heapless = "0.6"
 num-traits = "0.2"
-pdqselect = "=0.1.0"
 serde = { version = "1.0", optional = true, features = ["derive"] }
 smallvec = "1.6"
 

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -206,7 +206,7 @@ where
         envelopes: &mut [T],
         selection_size: usize,
     ) {
-        ::pdqselect::select_by(envelopes, selection_size, |l, r| {
+        envelopes.select_nth_unstable_by(selection_size, |l, r| {
             l.envelope()
                 .lower
                 .nth(axis)


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Pros:
- Fewer dependencies!
- Switching to `select_unstable` (rather than `stable`) should be faster. I can run a few benchmarks to back this up with numbers if desired. A stable sort is not required for the algorithm to work correctly

Cons:
- Bumps the minimal supported rust version (MSRV)  to 1.49

------------------
What's the thought about the MSRV? Is it okay to rely on 1.49? V1.49 was released on 2020-12-31