### PR TITLE
Geo points and custom distance metric

### DIFF
--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -19,6 +19,7 @@ heapless = "0.6"
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
 smallvec = "1.6"
+geo-types = "0.7"
 
 [features]
 default = []

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -30,7 +30,7 @@ where
 
 impl<P> AABB<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     /// Returns the AABB encompassing a single point.
     pub fn from_point(p: P) -> Self {
@@ -98,7 +98,7 @@ where
 
 impl<P> Envelope for AABB<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     type Point = P;
 
@@ -216,7 +216,7 @@ where
     }
 }
 
-fn new_empty<P: Point>() -> AABB<P> {
+fn new_empty<P: Point + PointExt>() -> AABB<P> {
     let max = P::Scalar::max_value();
     let min = P::Scalar::min_value();
     AABB {

--- a/rstar/src/envelope.rs
+++ b/rstar/src/envelope.rs
@@ -1,4 +1,4 @@
-use crate::{Point, RTreeObject};
+use crate::{Point, PointExt, RTreeObject};
 
 /// An envelope type that encompasses some child nodes.
 ///
@@ -8,7 +8,7 @@ use crate::{Point, RTreeObject};
 /// exists ([crate::AABB]) and should be used.
 pub trait Envelope: Clone + Copy + PartialEq + ::core::fmt::Debug {
     /// The envelope's point type.
-    type Point: Point;
+    type Point: Point + PointExt;
 
     /// Creates a new, empty envelope that does not encompass any child.
     fn new_empty() -> Self;

--- a/rstar/src/geopoint.rs
+++ b/rstar/src/geopoint.rs
@@ -1,0 +1,112 @@
+use crate::PointExt;
+use geo_types;
+
+type LonLatFloat = f32;
+
+#[derive(PartialEq, Clone, Copy, Debug, Default)]
+struct GeoPoint(geo_types::Point<LonLatFloat>);
+
+impl GeoPoint {
+    const RE: f64 = 6378.137; // equatorial radius in km
+    const FE: f64 = 1.0 / 298.257223563; // flattening
+    const E2: f64 = Self::FE * (2.0 - Self::FE);
+
+    pub fn new(x: LonLatFloat, y: LonLatFloat) -> Self {
+        GeoPoint(geo_types::Point::new(x, y))
+    }
+
+    fn x(&self) -> LonLatFloat {
+        self.0.x()
+    }
+
+    fn y(&self) -> LonLatFloat {
+        self.0.y()
+    }
+
+    fn long_diff(a: LonLatFloat, b: LonLatFloat) -> LonLatFloat {
+        let threesixty = 360.;
+        let diff = a - b;
+        diff - ((diff / threesixty).round() * threesixty)
+    }
+
+    fn multipliers_for_lonlat_converstion(latitude: LonLatFloat) -> (LonLatFloat, LonLatFloat) {
+        let one = 1.;
+        let e2 = Self::E2 as LonLatFloat;
+
+        // Curvature formulas from https://en.wikipedia.org/wiki/Earth_radius#Meridional
+        let coslat = latitude.to_radians().cos();
+        let w2 = one / (one - e2 * (one - coslat * coslat));
+        let w = w2.sqrt();
+
+        // multipliers for converting longitude and latitude degrees into distance
+        let dkx = w * coslat; // based on normal radius of curvature
+        let dky = w * w2 * (one - e2); // based on meridonal radius of curvature
+
+        Self::calculate_multipliers(dkx, dky)
+    }
+
+    fn calculate_multipliers(dkx: LonLatFloat, dky: LonLatFloat) -> (LonLatFloat, LonLatFloat) {
+        let re = Self::RE as LonLatFloat;
+        let mul = (1000. as LonLatFloat).to_radians() * re;
+        let kx = mul * dkx;
+        let ky = mul * dky;
+        (kx, ky)
+    }
+}
+
+impl PointExt for GeoPoint {
+    fn sub(&self, other: &Self) -> Self {
+        let (kx, ky) = Self::multipliers_for_lonlat_converstion(other.y());
+        let dx = Self::long_diff(other.x(), self.x()) * kx;
+        let dy = (other.y() - self.y()) * ky;
+        Self::new(dx, dy)
+    }
+}
+
+impl crate::Point for GeoPoint {
+    type Scalar = LonLatFloat;
+
+    const DIMENSIONS: usize = 2;
+
+    fn generate(mut generator: impl FnMut(usize) -> Self::Scalar) -> Self {
+        GeoPoint::new(generator(0), generator(1))
+    }
+
+    fn nth(&self, index: usize) -> Self::Scalar {
+        match index {
+            0 => self.0 .0.x,
+            1 => self.0 .0.y,
+            _ => unreachable!(),
+        }
+    }
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        match index {
+            0 => &mut self.0 .0.x,
+            1 => &mut self.0 .0.y,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GeoPoint;
+    use crate::RTree;
+
+    #[test]
+    fn test_rtree() {
+        let p1_lat = 55.574778_f32;
+        let p1_long = 38.057070;
+        let p2_lat = 55.634198_f32;
+        let p2_long = 38.087196;
+
+        let q_lat = 55.61;
+        let q_long = 38.06;
+
+        let mut tree = RTree::new();
+        tree.insert(GeoPoint::new(p1_long, p1_lat));
+        tree.insert(GeoPoint::new(p2_long, p2_lat));
+        let nn = tree.nearest_neighbor(&GeoPoint::new(q_long, q_lat));
+        println!("{nn:?}");
+    }
+}

--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -45,7 +45,7 @@ pub use crate::envelope::Envelope;
 pub use crate::node::{ParentNode, RTreeNode};
 pub use crate::object::{PointDistance, RTreeObject};
 pub use crate::params::{DefaultParams, InsertionStrategy, RTreeParams};
-pub use crate::point::{Point, RTreeNum};
+pub use crate::point::{Point, PointExt, RTreeNum};
 pub use crate::rtree::RTree;
 
 pub use crate::algorithm::iterators;

--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -28,6 +28,7 @@ extern crate alloc;
 mod aabb;
 mod algorithm;
 mod envelope;
+mod geopoint;
 mod node;
 mod object;
 mod params;

--- a/rstar/src/object.rs
+++ b/rstar/src/object.rs
@@ -191,7 +191,7 @@ pub trait PointDistance: RTreeObject {
 
 impl<P> RTreeObject for P
 where
-    P: Point,
+    P: Point + PointExt,
 {
     type Envelope = AABB<P>;
 
@@ -202,7 +202,7 @@ where
 
 impl<P> PointDistance for P
 where
-    P: Point,
+    P: Point + PointExt,
 {
     fn distance_2(&self, point: &P) -> P::Scalar {
         <Self as PointExt>::distance_2(self, point)

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -335,6 +335,9 @@ macro_rules! implement_point_for_array {
                 &mut self[index]
             }
         }
+        impl<S> PointExt for [S; count_exprs!($($index),*)]
+        where
+            S: RTreeNum {}
     };
 }
 
@@ -387,6 +390,10 @@ macro_rules! impl_point_for_tuple {
                 }
             }
         }
+
+        impl<S> PointExt for ($(fixed_type!($index, S),)+)
+        where
+            S: RTreeNum {}
     };
 }
 

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -1,5 +1,5 @@
-use num_traits::{Bounded, Num, Signed, Zero};
 use core::fmt::Debug;
+use num_traits::{Bounded, Num, Signed, Zero};
 
 /// Defines a number type that is compatible with rstar.
 ///
@@ -179,7 +179,7 @@ pub trait Point: Copy + Clone + PartialEq + Debug {
     fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar;
 }
 
-impl<T> PointExt for T where T: Point {}
+// impl<T> PointExt for T where T: Point {}
 
 /// Utility functions for Point
 pub trait PointExt: Point {

--- a/rstar/src/primitives/line.rs
+++ b/rstar/src/primitives/line.rs
@@ -46,7 +46,7 @@ where
 
 impl<P> RTreeObject for Line<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     type Envelope = AABB<P>;
 
@@ -57,7 +57,7 @@ where
 
 impl<P> Line<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     /// Returns the squared length of this line.
     ///
@@ -105,7 +105,7 @@ where
 
 impl<P> PointDistance for Line<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     fn distance_2(
         &self,

--- a/rstar/src/primitives/point_with_data.rs
+++ b/rstar/src/primitives/point_with_data.rs
@@ -1,4 +1,4 @@
-use crate::{Point, PointDistance, RTreeObject, AABB};
+use crate::{Point, PointDistance, PointExt, RTreeObject, AABB};
 
 /// A point with some associated data that can be inserted into an r-tree.
 ///
@@ -49,7 +49,7 @@ impl<T, P> PointWithData<T, P> {
 
 impl<T, P> RTreeObject for PointWithData<T, P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     type Envelope = AABB<P>;
 
@@ -60,7 +60,7 @@ where
 
 impl<T, P> PointDistance for PointWithData<T, P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     fn distance_2(&self, point: &P) -> <P as Point>::Scalar {
         self.point.distance_2(point)

--- a/rstar/src/primitives/rectangle.rs
+++ b/rstar/src/primitives/rectangle.rs
@@ -23,7 +23,7 @@ where
 
 impl<P> Rectangle<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     /// Creates a new rectangle defined by two corners.
     pub fn from_corners(corner_1: P, corner_2: P) -> Self {
@@ -54,7 +54,7 @@ where
 
 impl<P> From<AABB<P>> for Rectangle<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     fn from(aabb: AABB<P>) -> Self {
         Self::from_aabb(aabb)
@@ -63,7 +63,7 @@ where
 
 impl<P> RTreeObject for Rectangle<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     type Envelope = AABB<P>;
 
@@ -74,7 +74,7 @@ where
 
 impl<P> Rectangle<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     /// Returns the nearest point within this rectangle to a given point.
     ///
@@ -86,7 +86,7 @@ where
 
 impl<P> PointDistance for Rectangle<P>
 where
-    P: Point,
+    P: Point + PointExt,
 {
     fn distance_2(
         &self,


### PR DESCRIPTION
- [ ] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---
This PR is a demo of an attempt to use rstar to store geo points (with longitude and latitude as x, y values) and run nearest neighbour algorithm between close points.

To implement the demo in external crate I have exposed PointExp trait to public interface and disabled default PointExp implementation for Point types except arrays and tuples.

I added the demo to `rstar/src/geopoint.rs`.

Custom `sub` method calculates approximate distance between two points on WGS84 ellipsoid model of the Earth(https://en.wikipedia.org/wiki/Earth_radius#Meridional), using the code from https://github.com/vipera/cheap-ruler-rs . This allows to calculate distances with acceptable precision up to ~500km which is good enough for my use case.
The method returns deltas along longitudes and latitudes scaled to distances in meters.

As I understand `PointExt` should be private. Is it better to introduce a public trait for coordinate metric distances and implement `PointExt::sub` method via something like `CoordMetricDistance::delta_between_points`?
