### PR TITLE
Upgrade to heapless v0.7.10 and update MSRV to 1.51.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,8 +32,9 @@ jobs:
     strategy:
       matrix:
         container_image:
-          - "georust/geo-ci:rust-1.50"
           - "georust/geo-ci:rust-1.51"
+          - "georust/geo-ci:rust-1.58"
+          - "georust/geo-ci:rust-1.59"
     container:
       image: ${{ matrix.container_image }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,9 @@ jobs:
         working-directory: rstar
     strategy:
       matrix:
-        container_image: ["georust/geo-ci:rust-1.50", "georust/geo-ci:rust-1.51"]
+        container_image:
+          - "georust/geo-ci:rust-1.50"
+          - "georust/geo-ci:rust-1.51"
     container:
       image: ${{ matrix.container_image }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,9 @@ jobs:
     strategy:
       matrix:
         container_image:
+          # Minimum supported rust version (MSRV)
           - "georust/geo-ci:rust-1.51"
+          # Two most recent releases - older ones are omitted.
           - "georust/geo-ci:rust-1.58"
           - "georust/geo-ci:rust-1.59"
     container:

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 ## Changed
 - Removed dependency on `pdqselect` ([PR](https://github.com/georust/rstar/pull/85))
-- New **minimal supported rust version (MSRV): 1.51.0**
+- BREAKING: New **minimal supported rust version (MSRV): 1.51.0**
 - Replace all usages of `std` with `core` & `alloc` to make `rstar` fit for
   `no_std`. ([PR](https://github.com/georust/rstar/pull/83))
 - Updated `heapless` dependency to 0.7 to make use of const generics. ([PR](https://github.com/georust/rstar/pull/87))

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Unreleased
 ## Changed
 - Removed dependency on `pdqselect` ([PR](https://github.com/georust/rstar/pull/85))
-- New **minimal supported rust version (MSRV): 1.49.0**
+- New **minimal supported rust version (MSRV): 1.51.0**
 - Replace all usages of `std` with `core` & `alloc` to make `rstar` fit for
   `no_std`. ([PR](https://github.com/georust/rstar/pull/83))
+- Updated `heapless` dependency to 0.7 to make use of const generics. ([PR](https://github.com/georust/rstar/pull/87))
 
 # 0.9.2
 - Add `RTree::drain_*` methods to remove and drain selected items. ([PR](https://github.com/georust/rstar/pull/77))

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 ## Changed
 - Removed dependency on `pdqselect` ([PR](https://github.com/georust/rstar/pull/85))
-- BREAKING: New **minimal supported rust version (MSRV): 1.51.0**
+- New **minimal supported rust version (MSRV): 1.51.0**
 - Replace all usages of `std` with `core` & `alloc` to make `rstar` fit for
   `no_std`. ([PR](https://github.com/georust/rstar/pull/83))
 - Updated `heapless` dependency to 0.7 to make use of const generics. ([PR](https://github.com/georust/rstar/pull/87))

--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -8,6 +8,7 @@ repository = "https://github.com/georust/rstar"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 edition = "2018"
+rust-version = "1.51"
 keywords = ["rtree", "r-tree", "rstar", "spatial", "nearest-neighbor"]
 categories = ["data-structures", "algorithms"]
 

--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -15,7 +15,7 @@ categories = ["data-structures", "algorithms"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-heapless = "0.6"
+heapless = "0.7"
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
 smallvec = "1.6"

--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -16,7 +16,7 @@ categories = ["data-structures", "algorithms"]
 maintenance = { status = "actively-developed" }
 
 [dependencies]
-heapless = "0.7"
+heapless = "0.7.10"
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
 smallvec = "1.6"

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -141,7 +141,7 @@ where
 }
 
 enum SmallHeap<T: Ord> {
-    Stack(static_heap::BinaryHeap<T, heapless::consts::U32, static_heap::Max>),
+    Stack(static_heap::BinaryHeap<T, static_heap::Max, 32>),
     Heap(BinaryHeap<T>),
 }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

[Rust 1.51](https://blog.rust-lang.org/2021/03/25/Rust-1.51.0.html) has been released for nearly 12 months now.

As the community upgrades through and past this Rust version, some required dependencies of `rstar` (namely, `heapless` v0.6, which itself required the `as-slice` and `generic-array` dependencies before Rust 1.51) have since released updates to make use of the new Const Generics MVP functionality that was released with Rust 1.51.

To remove a few outdated dependencies and upgrade the codebase to the latest version of `heapless`, this PR does the following:

- Upgrades the `heapless` dependency from 0.6 to 0.7.

  This broke my local compile, as `heapless`' signature for the `heapless::binary_heap::BinaryHeap` type changed, and the `heapless::consts::U32` can now be represented with a plain old `32_usize`. I made changes to `src/algorithm/nearest_neighbor.rs` to fix the compile, and this resolved the compile failure. The tests now seem to pass.
  
- Updates the CI workflows file to test versions as far back as Rust 1.51 (but not Rust 1.50), as well as two more recent MSRVs.

- Updates the `rstar/Cargo.toml` file to specify a `rust-version` key to indicate that Rust 1.51 is the Minimum Supported Rust Version (MSRV). This will display a warning on versions of cargo older than that which was distributed with Rust 1.56, as the `rust-version` key was added in that release.