### PR TITLE
Fix panic when setting RTreeParams MIN_SIZE to 1

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Replace all usages of `std` with `core` & `alloc` to make `rstar` fit for
   `no_std`. ([PR](https://github.com/georust/rstar/pull/83))
 - Updated `heapless` dependency to 0.7 to make use of const generics. ([PR](https://github.com/georust/rstar/pull/87))
+- Fixed error when setting MIN_SIZE = 1 in `RTreeParams` and added assert for positive MIN_SIZE
 
 # 0.9.2
 - Add `RTree::drain_*` methods to remove and drain selected items. ([PR](https://github.com/georust/rstar/pull/77))

--- a/rstar/src/algorithm/removal.rs
+++ b/rstar/src/algorithm/removal.rs
@@ -58,7 +58,7 @@ where
         let original_size = replace(rtree.size_mut(), 0);
 
         let m = Params::MIN_SIZE;
-        let max_depth = (original_size as f32).log(m as f32).ceil() as usize;
+        let max_depth = (original_size as f32).log(m.max(2) as f32).ceil() as usize;
         let mut node_stack = Vec::with_capacity(max_depth);
         node_stack.push((root, 0, 0));
 

--- a/rstar/src/params.rs
+++ b/rstar/src/params.rs
@@ -91,6 +91,7 @@ pub fn verify_parameters<T: RTreeObject, P: RTreeParams>() {
         "MAX_SIZE too small. Must be larger than 4."
     );
 
+    assert!(P::MIN_SIZE > 0, "MIN_SIZE must be at least 1",);
     let max_min_size = (P::MAX_SIZE + 1) / 2;
     assert!(
         P::MIN_SIZE <= max_min_size,

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -362,6 +362,7 @@ where
     /// let elements_intersecting_large_piece = tree.locate_in_envelope_intersecting(&large_piece);
     /// // Any element that is fully contained should also be returned:
     /// assert_eq!(elements_intersecting_large_piece.count(), 3);
+    /// ```
     pub fn locate_in_envelope_intersecting(
         &self,
         envelope: &T::Envelope,
@@ -853,6 +854,25 @@ mod test {
         const MAX_SIZE: usize = 20;
         const REINSERTION_COUNT: usize = 1;
         type DefaultInsertionStrategy = RStarInsertionStrategy;
+    }
+
+    #[test]
+    fn test_remove_capacity() {
+        pub struct WeirdParams;
+
+        impl RTreeParams for WeirdParams {
+            const MIN_SIZE: usize = 1;
+            const MAX_SIZE: usize = 10;
+            const REINSERTION_COUNT: usize = 1;
+            type DefaultInsertionStrategy = RStarInsertionStrategy;
+        }
+
+        let mut items: Vec<[f32; 2]> = Vec::new();
+        for i in 0..2 {
+            items.push([i as f32, i as f32]);
+        }
+        let mut tree: RTree<_, WeirdParams> = RTree::bulk_load_with_params(items);
+        assert_eq!(tree.remove(&[1.0, 1.0]).unwrap(), [1.0, 1.0]);
     }
 
     #[test]


### PR DESCRIPTION
rstar's capacity-calculation logic would attempt to set the underlying vec's capacity to 2^64 -1 as a result, causing a panic because this exceeds the max value of isize on 64-bit platforms. This fix adds a check for MIN_SIZE = 1 when calculating capacity.

The fix currently sets the max depth to 1 – should it be higher?

Fixes #92

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

