### PR TITLE
Add pub fn RTree::drain()

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Added
+- Added method `RTree::drain()`.
+
 ## Changed
 - fixed all clippy lint issues
 - Fixed error when setting MIN_SIZE = 1 in `RTreeParams` and added assert for positive MIN_SIZE

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -319,6 +319,17 @@ where
         LocateInEnvelopeMut::new(&mut self.root, SelectInEnvelopeFunction::new(*envelope))
     }
 
+    /// Returns a draining iterator over all elements contained in the tree.
+    ///
+    /// The order in which the elements are returned is not specified.
+    ///
+    /// See
+    /// [drain_with_selection_function](#method.drain_with_selection_function)
+    /// for more information.
+    pub fn drain(&mut self) -> DrainIterator<T, SelectAllFunc, Params> {
+        self.drain_with_selection_function(SelectAllFunc)
+    }
+
     /// Draining variant of [locate_in_envelope](#method.locate_in_envelope).
     pub fn drain_in_envelope(
         &mut self,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

