### PR TITLE
Remove Copy bound on Point and Envelope?

### DIFF
--- a/rstar-benches/benches/benchmarks.rs
+++ b/rstar-benches/benches/benchmarks.rs
@@ -44,7 +44,7 @@ fn bulk_load_comparison(c: &mut Criterion) {
         b.iter(move || {
             let mut rtree = rstar::RTree::new();
             for point in &points {
-                rtree.insert(*point);
+                rtree.insert(point.clone());
             }
         });
     });
@@ -57,7 +57,7 @@ fn tree_creation_quality(c: &mut Criterion) {
     let tree_bulk_loaded = RTree::<_, Params>::bulk_load_with_params(points.clone());
     let mut tree_sequential = RTree::new();
     for point in &points {
-        tree_sequential.insert(*point);
+        tree_sequential.insert(point.clone());
     }
 
     let query_points = create_random_points(100, SEED_2);

--- a/rstar-demo/src/two_d.rs
+++ b/rstar-demo/src/two_d.rs
@@ -10,7 +10,7 @@ pub fn create_render_data_for_tree_2d(tree: &DemoTree2D) -> RenderData {
         for child in cur.children() {
             match child {
                 RTreeNode::Leaf(point) => {
-                    push_2d_point(&mut lines, *point);
+                    push_2d_point(&mut lines, point.clone());
                 }
                 RTreeNode::Parent(ref data) => {
                     to_visit.push((data, depth + 1));

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -6,6 +6,7 @@
 ## Changed
 - fixed all clippy lint issues
 - Fixed error when setting MIN_SIZE = 1 in `RTreeParams` and added assert for positive MIN_SIZE
+- Removed the `Copy` bound from `Point` and `Envelope`.
 
 # 0.9.3
 ## Changed

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -6,7 +6,7 @@
 ## Changed
 - fixed all clippy lint issues
 - Fixed error when setting MIN_SIZE = 1 in `RTreeParams` and added assert for positive MIN_SIZE
-- Removed the `Copy` bound from `Point` and `Envelope`.
+- BREAKING: Removed the `Copy` bound from `Point` and `Envelope`. ([PR](https://github.com/georust/rstar/pull/103))
 
 # 0.9.3
 ## Changed

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -34,7 +34,10 @@ where
 {
     /// Returns the AABB encompassing a single point.
     pub fn from_point(p: P) -> Self {
-        AABB { lower: p.clone(), upper: p.clone() }
+        AABB {
+            lower: p.clone(),
+            upper: p.clone(),
+        }
     }
 
     /// Returns the AABB's lower corner.

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -34,7 +34,7 @@ where
 {
     /// Returns the AABB encompassing a single point.
     pub fn from_point(p: P) -> Self {
-        AABB { lower: p, upper: p }
+        AABB { lower: p.clone(), upper: p.clone() }
     }
 
     /// Returns the AABB's lower corner.
@@ -42,7 +42,7 @@ where
     /// This is the point contained within the AABB with the smallest coordinate value in each
     /// dimension.
     pub fn lower(&self) -> P {
-        self.lower
+        self.lower.clone()
     }
 
     /// Returns the AABB's upper corner.
@@ -50,7 +50,7 @@ where
     /// This is the point contained within the AABB with the largest coordinate value in each
     /// dimension.
     pub fn upper(&self) -> P {
-        self.upper
+        self.upper.clone()
     }
 
     /// Creates a new AABB encompassing two points.

--- a/rstar/src/algorithm/iterators.rs
+++ b/rstar/src/algorithm/iterators.rs
@@ -261,7 +261,7 @@ mod test {
         let points = create_random_points(NUM_POINTS, SEED_1);
         let mut tree = RTree::new();
         for p in &points {
-            tree.insert(*p);
+            tree.insert(p.clone());
         }
         let mut count = 0usize;
         for p in tree.iter() {

--- a/rstar/src/algorithm/iterators.rs
+++ b/rstar/src/algorithm/iterators.rs
@@ -7,8 +7,8 @@ use crate::RTree;
 
 use smallvec::SmallVec;
 
-pub use super::removal::DrainIterator;
 pub use super::intersection_iterator::IntersectionIterator;
+pub use super::removal::DrainIterator;
 
 /// Iterator returned by [`RTree::locate_all_at_point`].
 pub type LocateAllAtPoint<'a, T> = SelectionIterator<'a, T, SelectAtPointFunction<T>>;

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -223,14 +223,14 @@ where
     let mut smallest_min_max: <<T::Envelope as Envelope>::Point as Point>::Scalar =
         Bounded::max_value();
     let mut nodes = SmallHeap::new();
-    extend_heap(&mut nodes, node, query_point, &mut smallest_min_max);
+    extend_heap(&mut nodes, node, query_point.clone(), &mut smallest_min_max);
     while let Some(current) = nodes.pop() {
         match current {
             RTreeNodeDistanceWrapper {
                 node: RTreeNode::Parent(ref data),
                 ..
             } => {
-                extend_heap(&mut nodes, data, query_point, &mut smallest_min_max);
+                extend_heap(&mut nodes, data, query_point.clone(), &mut smallest_min_max);
             }
             RTreeNodeDistanceWrapper {
                 node: RTreeNode::Leaf(ref t),
@@ -250,7 +250,7 @@ pub fn nearest_neighbors<T>(
 where
     T: PointDistance,
 {
-    let mut nearest_neighbors = NearestNeighborIterator::new(node, query_point);
+    let mut nearest_neighbors = NearestNeighborIterator::new(node, query_point.clone());
 
     let first_nearest_neighbor = match nearest_neighbors.next() {
         None => return vec![], // If we have an empty tree, just return an empty vector.

--- a/rstar/src/algorithm/rstar.rs
+++ b/rstar/src/algorithm/rstar.rs
@@ -186,7 +186,7 @@ where
 
         for (index, child1) in node.children.iter().enumerate() {
             let envelope = child1.envelope();
-            let mut new_envelope = envelope;
+            let mut new_envelope = envelope.clone();
             new_envelope.merge(&insertion_envelope);
             let overlap_increase = if all_leaves {
                 // Calculate minimal overlap increase
@@ -307,8 +307,8 @@ where
             second_envelope.merge(&child.envelope());
         }
         for k in min_size..until {
-            let mut first_modified = first_envelope;
-            let mut second_modified = second_envelope;
+            let mut first_modified = first_envelope.clone();
+            let mut second_modified = second_envelope.clone();
             let (l, r) = node.children.split_at(k);
             for child in l {
                 first_modified.merge(&child.envelope());

--- a/rstar/src/envelope.rs
+++ b/rstar/src/envelope.rs
@@ -6,7 +6,7 @@ use crate::{Point, RTreeObject};
 /// e.g. how they can be merged or intersected.
 /// This trait is not meant to be implemented by the user. Currently, only one implementation
 /// exists ([crate::AABB]) and should be used.
-pub trait Envelope: Clone + Copy + PartialEq + ::core::fmt::Debug {
+pub trait Envelope: Clone + PartialEq + ::core::fmt::Debug {
     /// The envelope's point type.
     type Point: Point;
 

--- a/rstar/src/node.rs
+++ b/rstar/src/node.rs
@@ -53,7 +53,7 @@ where
     fn envelope(&self) -> Self::Envelope {
         match self {
             RTreeNode::Leaf(ref t) => t.envelope(),
-            RTreeNode::Parent(ref data) => data.envelope,
+            RTreeNode::Parent(ref data) => data.envelope.clone(),
         }
     }
 }
@@ -82,7 +82,7 @@ where
 
     /// Returns the smallest envelope that encompasses all children.
     pub fn envelope(&self) -> T::Envelope {
-        self.envelope
+        self.envelope.clone()
     }
 
     pub(crate) fn new_root<Params>() -> Self

--- a/rstar/src/object.rs
+++ b/rstar/src/object.rs
@@ -196,7 +196,7 @@ where
     type Envelope = AABB<P>;
 
     fn envelope(&self) -> AABB<P> {
-        AABB::from_point(*self)
+        AABB::from_point(self.clone())
     }
 }
 

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -156,7 +156,7 @@ impl<S> RTreeNum for S where S: Bounded + Num + Clone + Copy + Signed + PartialO
 ///   }
 /// }
 /// ```
-pub trait Point: Copy + Clone + PartialEq + Debug {
+pub trait Point: Clone + PartialEq + Debug {
     /// The number type used by this point type.
     type Scalar: RTreeNum;
 

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -1,5 +1,5 @@
-use num_traits::{Bounded, Num, Signed, Zero};
 use core::fmt::Debug;
+use num_traits::{Bounded, Num, Signed, Zero};
 
 /// Defines a number type that is compatible with rstar.
 ///

--- a/rstar/src/primitives/line.rs
+++ b/rstar/src/primitives/line.rs
@@ -51,7 +51,7 @@ where
     type Envelope = AABB<P>;
 
     fn envelope(&self) -> Self::Envelope {
-        AABB::from_corners(self.from, self.to)
+        AABB::from_corners(self.from.clone(), self.to.clone())
     }
 }
 
@@ -73,7 +73,7 @@ where
     }
 
     fn project_point(&self, query_point: &P) -> P::Scalar {
-        let (ref p1, ref p2) = (self.from, self.to);
+        let (ref p1, ref p2) = (self.from.clone(), self.to.clone());
         let dir = p2.sub(p1);
         query_point.sub(p1).dot(&dir) / dir.length_2()
     }
@@ -90,7 +90,7 @@ where
     /// assert_eq!(line.nearest_point(&[10., 12.]), [1.0, 1.0]);
     /// ```
     pub fn nearest_point(&self, query_point: &P) -> P {
-        let (p1, p2) = (self.from, self.to);
+        let (p1, p2) = (self.from.clone(), self.to.clone());
         let dir = p2.sub(&p1);
         let s = self.project_point(query_point);
         if P::Scalar::zero() < s && s < One::one() {

--- a/rstar/src/primitives/rectangle.rs
+++ b/rstar/src/primitives/rectangle.rs
@@ -68,7 +68,7 @@ where
     type Envelope = AABB<P>;
 
     fn envelope(&self) -> Self::Envelope {
-        self.aabb
+        self.aabb.clone()
     }
 }
 

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -311,12 +311,12 @@ where
     /// assert_eq!(elements_in_unit_square.count(), 3);
     /// ```
     pub fn locate_in_envelope(&self, envelope: &T::Envelope) -> LocateInEnvelope<T> {
-        LocateInEnvelope::new(&self.root, SelectInEnvelopeFunction::new(*envelope))
+        LocateInEnvelope::new(&self.root, SelectInEnvelopeFunction::new(envelope.clone()))
     }
 
     /// Mutable variant of [locate_in_envelope](#method.locate_in_envelope).
     pub fn locate_in_envelope_mut(&mut self, envelope: &T::Envelope) -> LocateInEnvelopeMut<T> {
-        LocateInEnvelopeMut::new(&mut self.root, SelectInEnvelopeFunction::new(*envelope))
+        LocateInEnvelopeMut::new(&mut self.root, SelectInEnvelopeFunction::new(envelope.clone()))
     }
 
     /// Returns a draining iterator over all elements contained in the tree.
@@ -380,7 +380,7 @@ where
     ) -> LocateInEnvelopeIntersecting<T> {
         LocateInEnvelopeIntersecting::new(
             &self.root,
-            SelectInEnvelopeFuncIntersecting::new(*envelope),
+            SelectInEnvelopeFuncIntersecting::new(envelope.clone()),
         )
     }
 
@@ -391,7 +391,7 @@ where
     ) -> LocateInEnvelopeIntersectingMut<T> {
         LocateInEnvelopeIntersectingMut::new(
             &mut self.root,
-            SelectInEnvelopeFuncIntersecting::new(*envelope),
+            SelectInEnvelopeFuncIntersecting::new(envelope.clone()),
         )
     }
 
@@ -550,7 +550,7 @@ where
         &self,
         point: &<T::Envelope as Envelope>::Point,
     ) -> LocateAllAtPoint<T> {
-        LocateAllAtPoint::new(&self.root, SelectAtPointFunction::new(*point))
+        LocateAllAtPoint::new(&self.root, SelectAtPointFunction::new(point.clone()))
     }
 
     /// Mutable variant of [locate_all_at_point](#method.locate_all_at_point).
@@ -558,7 +558,7 @@ where
         &mut self,
         point: &<T::Envelope as Envelope>::Point,
     ) -> LocateAllAtPointMut<T> {
-        LocateAllAtPointMut::new(&mut self.root, SelectAtPointFunction::new(*point))
+        LocateAllAtPointMut::new(&mut self.root, SelectAtPointFunction::new(point.clone()))
     }
 
     /// Removes an element containing a given point.
@@ -581,7 +581,7 @@ where
     /// assert!(tree.remove_at_point(&[1.5, 1.5]).is_none());
     ///```
     pub fn remove_at_point(&mut self, point: &<T::Envelope as Envelope>::Point) -> Option<T> {
-        let removal_function = SelectAtPointFunction::new(*point);
+        let removal_function = SelectAtPointFunction::new(point.clone());
         self.remove_with_selection_function(removal_function)
     }
 }
@@ -660,7 +660,7 @@ where
         if self.size > 0 {
             // The single-nearest-neighbor retrieval may in rare cases return None due to
             // rounding issues. The iterator will still work, though.
-            nearest_neighbor::nearest_neighbor(&self.root, *query_point)
+            nearest_neighbor::nearest_neighbor(&self.root, query_point.clone())
                 .or_else(|| self.nearest_neighbor_iter(query_point).next())
         } else {
             None
@@ -687,7 +687,7 @@ where
     /// assert_eq!(tree.nearest_neighbors(&[0.01, 0.01]), &[&[0.0, 0.0]]);
     /// ```
     pub fn nearest_neighbors(&self, query_point: &<T::Envelope as Envelope>::Point) -> Vec<&T> {
-        nearest_neighbor::nearest_neighbors(&self.root, *query_point)
+        nearest_neighbor::nearest_neighbors(&self.root, query_point.clone())
     }
 
     /// Returns all elements of the tree within a certain distance.
@@ -743,7 +743,7 @@ where
         &self,
         query_point: &<T::Envelope as Envelope>::Point,
     ) -> NearestNeighborIterator<T> {
-        nearest_neighbor::NearestNeighborIterator::new(&self.root, *query_point)
+        nearest_neighbor::NearestNeighborIterator::new(&self.root, query_point.clone())
     }
 
     /// Returns `(element, distance^2)` tuples of the tree sorted by their distance to a given point.
@@ -755,7 +755,7 @@ where
         &self,
         query_point: &<T::Envelope as Envelope>::Point,
     ) -> NearestNeighborDistance2Iterator<T> {
-        nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, *query_point)
+        nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, query_point.clone())
     }
 
     /// Returns `(element, distance^2)` tuples of the tree sorted by their distance to a given point.
@@ -766,7 +766,7 @@ where
         &self,
         query_point: &<T::Envelope as Envelope>::Point,
     ) -> NearestNeighborDistance2Iterator<T> {
-        nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, *query_point)
+        nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, query_point.clone())
     }
 
     /// Removes the nearest neighbor for a given point and returns it.

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -316,7 +316,10 @@ where
 
     /// Mutable variant of [locate_in_envelope](#method.locate_in_envelope).
     pub fn locate_in_envelope_mut(&mut self, envelope: &T::Envelope) -> LocateInEnvelopeMut<T> {
-        LocateInEnvelopeMut::new(&mut self.root, SelectInEnvelopeFunction::new(envelope.clone()))
+        LocateInEnvelopeMut::new(
+            &mut self.root,
+            SelectInEnvelopeFunction::new(envelope.clone()),
+        )
     }
 
     /// Returns a draining iterator over all elements contained in the tree.


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---
I have not yet updated the CHANGELOG, because I don't know if this change is desirable for the maintainers. If it is, I will update as necessary.

I have a use case [in fenris](https://github.com/InteractiveComputerGraphics/fenris) where I'm working on heavily generic code based on `nalgebra`'s typenum based traits, and I'd like to use `rstar` for some spatial queries. Since my use of `rstar` here is supposed to be an implementation detail, I cannot add trait bounds, and for complex reasons related to deficiencies of the Rust type system, I can't make it work with the current `Point: Copy` and `Envelope: Copy` bounds. I was curious to see how necessary it is, and it turns out that these bounds can be removed without any breaking changes (as far as I can tell) by sprinkling some `.clone()` calls in various places.

Would it be interesting for you to lift the `Copy` bound? If not I might have to maintain my own fork just for `fenris`, which I'd rather like to avoid, but I can understand if you don't want to remove the bound.

Below is the output of `cargo bench`, by first running it on the current `master` branch, and afterwards on this branch. I tried to run it under the exact same conditions by shutting down most running background applications. For some reason one of the benchmarks reports being 6% faster, which I must still attribute to noise or random optimizer shenanigans, as I don't see how the changes I've made should make anything faster.

```
     Running benches/benchmarks.rs (target/release/deps/benchmarks-78cc23f600fbf43e)
Bulk load baseline      time:   [140.61 µs 140.64 µs 140.67 µs]                               
                        change: [-0.1287% -0.0943% -0.0606%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 1 outliers among 100 measurements (1.00%)
  1 (1.00%) high mild

Benchmarking rstar and spade benchmarks/rstar sequential: Warming up for 3.0000 s
Warning: Unable to complete 100 samples in 5.0s. You may wish to increase target time to 6.1s, enable flat sampling, or reduce sample count to 60.
rstar and spade benchmarks/rstar sequential                                                                             
                        time:   [1.1893 ms 1.1895 ms 1.1896 ms]
                        change: [-2.1223% -2.0942% -2.0670%] (p = 0.00 < 0.05)
                        Performance has improved.

bulk load quality       time:   [129.00 µs 129.06 µs 129.13 µs]                              
                        change: [-0.7067% -0.6304% -0.5579%] (p = 0.00 < 0.05)
                        Change within noise threshold.

sequential load quality time:   [177.29 µs 177.31 µs 177.34 µs]                                    
                        change: [+0.8951% +0.9252% +0.9522%] (p = 0.00 < 0.05)
                        Change within noise threshold.
Found 8 outliers among 100 measurements (8.00%)
  1 (1.00%) low severe
  1 (1.00%) low mild
  5 (5.00%) high mild
  1 (1.00%) high severe

locate_at_point (successful)                                                                            
                        time:   [185.26 ns 185.71 ns 186.14 ns]
                        change: [-6.5996% -6.3658% -6.1379%] (p = 0.00 < 0.05)
                        Performance has improved.

locate_at_point (unsuccessful)                                                                            
                        time:   [313.00 ns 313.34 ns 313.68 ns]
                        change: [-0.2903% -0.1584% -0.0239%] (p = 0.02 < 0.05)
                        Change within noise threshold.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild

     Running unittests src/main.rs (target/release/deps/rstar_demo-a0db318fb3a605e3)

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```
