### PR TITLE
feat: dynamic rather than static parameters

### DIFF
--- a/rstar-demo/src/main.rs
+++ b/rstar-demo/src/main.rs
@@ -7,7 +7,7 @@ use kiss3d::window::Window;
 use nalgebra::{Point2, Point3, Vector2};
 use rand::distributions::Uniform;
 use rand::Rng;
-use rstar::{Point, RStarInsertionStrategy, RTree, RTreeNode, RTreeParams, AABB};
+use rstar::{Params, Point, RTree, RTreeNode, AABB};
 
 mod three_d;
 mod two_d;
@@ -67,14 +67,14 @@ impl Scene {
 
     fn reset_to_empty(&mut self) {
         match self.render_mode {
-            RenderMode::TwoD => self.tree_2d = Default::default(),
-            RenderMode::ThreeD => self.tree_3d = Default::default(),
+            RenderMode::TwoD => self.tree_2d = DemoTree2D::new_with_params(params()),
+            RenderMode::ThreeD => self.tree_3d = DemoTree3D::new_with_params(params()),
         }
     }
 
     fn bulk_load_tree_3d() -> DemoTree3D {
         let points_3d = create_random_points(500);
-        DemoTree3D::bulk_load_with_params(points_3d)
+        DemoTree3D::bulk_load_with_params(params(), points_3d)
     }
 
     fn bulk_load_tree_2d(window_width: u32, window_height: u32) -> DemoTree2D {
@@ -83,23 +83,19 @@ impl Scene {
             *x = *x * window_width as f32 * 0.5;
             *y = *y * window_height as f32 * 0.5;
         }
-        DemoTree2D::bulk_load_with_params(points_2d)
+        DemoTree2D::bulk_load_with_params(params(), points_2d)
     }
 }
 
-type DemoTree3D = RTree<TreePointType3D, Params>;
+fn params() -> Params {
+    Params::new(5, 9, 3)
+}
+
+type DemoTree3D = RTree<TreePointType3D>;
 type TreePointType3D = [f32; 3];
 
 type DemoTree2D = RTree<TreePointType2D>;
 type TreePointType2D = [f32; 2];
-
-pub struct Params;
-impl RTreeParams for Params {
-    const MIN_SIZE: usize = 5;
-    const MAX_SIZE: usize = 9;
-    const REINSERTION_COUNT: usize = 3;
-    type DefaultInsertionStrategy = RStarInsertionStrategy;
-}
 
 pub enum RenderData {
     ThreeD(

--- a/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
+++ b/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
@@ -11,7 +11,7 @@ use num_traits::Float;
 
 use super::cluster_group_iterator::{calculate_number_of_clusters_on_axis, ClusterGroupIterator};
 
-fn bulk_load_recursive<T>(params: &Params, elements: Vec<T>, depth: usize) -> ParentNode<T>
+fn bulk_load_recursive<T>(params: Params, elements: Vec<T>, depth: usize) -> ParentNode<T>
 where
     T: RTreeObject,
     <T::Envelope as Envelope>::Point: Point,
@@ -65,7 +65,7 @@ impl<T: RTreeObject> Iterator for PartitioningTask<T> {
             } = next;
             if current_axis == 0 {
                 // Partitioning finished successfully on all axis. The remaining cluster forms a new node
-                let data = bulk_load_recursive::<_>(&self.params, elements, self.depth - 1);
+                let data = bulk_load_recursive::<_>(self.params, elements, self.depth - 1);
                 return RTreeNode::Parent(data).into();
             } else {
                 // The cluster group needs to be partitioned further along the next axis
@@ -88,7 +88,7 @@ impl<T: RTreeObject> Iterator for PartitioningTask<T> {
 /// A multi dimensional implementation of the OMT bulk loading algorithm.
 ///
 /// See http://ceur-ws.org/Vol-74/files/FORUM_18.pdf
-pub fn bulk_load_sequential<T>(params: &Params, elements: Vec<T>) -> ParentNode<T>
+pub fn bulk_load_sequential<T>(params: Params, elements: Vec<T>) -> ParentNode<T>
 where
     T: RTreeObject,
     <T::Envelope as Envelope>::Point: Point,

--- a/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
+++ b/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
@@ -1,7 +1,7 @@
 use crate::envelope::Envelope;
 use crate::node::{ParentNode, RTreeNode};
 use crate::object::RTreeObject;
-use crate::params::RTreeParams;
+use crate::params::Params;
 use crate::point::Point;
 
 use alloc::{vec, vec::Vec};
@@ -11,29 +11,28 @@ use num_traits::Float;
 
 use super::cluster_group_iterator::{calculate_number_of_clusters_on_axis, ClusterGroupIterator};
 
-fn bulk_load_recursive<T, Params>(elements: Vec<T>, depth: usize) -> ParentNode<T>
+fn bulk_load_recursive<T>(params: &Params, elements: Vec<T>, depth: usize) -> ParentNode<T>
 where
     T: RTreeObject,
     <T::Envelope as Envelope>::Point: Point,
-    Params: RTreeParams,
 {
-    let m = Params::MAX_SIZE;
+    let m = params.max_size();
     if elements.len() <= m {
         // Reached leaf level
         let elements: Vec<_> = elements.into_iter().map(RTreeNode::Leaf).collect();
         return ParentNode::new_parent(elements);
     }
     let number_of_clusters_on_axis =
-        calculate_number_of_clusters_on_axis::<T, Params>(elements.len());
+        calculate_number_of_clusters_on_axis::<T>(params, elements.len());
 
-    let iterator = PartitioningTask::<_, Params> {
+    let iterator = PartitioningTask::<_> {
         number_of_clusters_on_axis,
         depth,
         work_queue: vec![PartitioningState {
             current_axis: <T::Envelope as Envelope>::Point::DIMENSIONS,
             elements,
         }],
-        _params: Default::default(),
+        params: params.clone(),
     };
     ParentNode::new_parent(iterator.collect())
 }
@@ -48,14 +47,14 @@ struct PartitioningState<T: RTreeObject> {
 }
 
 /// Successively partitions the given elements into  cluster groups and finally into clusters.
-struct PartitioningTask<T: RTreeObject, Params: RTreeParams> {
+struct PartitioningTask<T: RTreeObject> {
     work_queue: Vec<PartitioningState<T>>,
     depth: usize,
     number_of_clusters_on_axis: usize,
-    _params: core::marker::PhantomData<Params>,
+    params: Params,
 }
 
-impl<T: RTreeObject, Params: RTreeParams> Iterator for PartitioningTask<T, Params> {
+impl<T: RTreeObject> Iterator for PartitioningTask<T> {
     type Item = RTreeNode<T>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -66,7 +65,7 @@ impl<T: RTreeObject, Params: RTreeParams> Iterator for PartitioningTask<T, Param
             } = next;
             if current_axis == 0 {
                 // Partitioning finished successfully on all axis. The remaining cluster forms a new node
-                let data = bulk_load_recursive::<_, Params>(elements, self.depth - 1);
+                let data = bulk_load_recursive::<_>(&self.params, elements, self.depth - 1);
                 return RTreeNode::Parent(data).into();
             } else {
                 // The cluster group needs to be partitioned further along the next axis
@@ -89,15 +88,14 @@ impl<T: RTreeObject, Params: RTreeParams> Iterator for PartitioningTask<T, Param
 /// A multi dimensional implementation of the OMT bulk loading algorithm.
 ///
 /// See http://ceur-ws.org/Vol-74/files/FORUM_18.pdf
-pub fn bulk_load_sequential<T, Params>(elements: Vec<T>) -> ParentNode<T>
+pub fn bulk_load_sequential<T>(params: &Params, elements: Vec<T>) -> ParentNode<T>
 where
     T: RTreeObject,
     <T::Envelope as Envelope>::Point: Point,
-    Params: RTreeParams,
 {
-    let m = Params::MAX_SIZE;
+    let m = params.max_size();
     let depth = (elements.len() as f32).log(m as f32).ceil() as usize;
-    bulk_load_recursive::<_, Params>(elements, depth)
+    bulk_load_recursive::<_>(params, elements, depth)
 }
 
 #[cfg(test)]

--- a/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
+++ b/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
@@ -1,4 +1,4 @@
-use crate::{Envelope, Point, RTreeObject, RTreeParams};
+use crate::{Envelope, Params, Point, RTreeObject};
 
 use alloc::vec::Vec;
 
@@ -47,12 +47,11 @@ impl<T: RTreeObject> Iterator for ClusterGroupIterator<T> {
 /// Calculates the desired number of clusters on any axis
 ///
 /// A 'cluster' refers to a set of elements that will finally form an rtree node.
-pub fn calculate_number_of_clusters_on_axis<T, Params>(number_of_elements: usize) -> usize
+pub fn calculate_number_of_clusters_on_axis<T>(params: &Params, number_of_elements: usize) -> usize
 where
     T: RTreeObject,
-    Params: RTreeParams,
 {
-    let max_size = Params::MAX_SIZE as f32;
+    let max_size = params.max_size() as f32;
     // The depth of the resulting tree, assuming all leaf nodes will be filled up to MAX_SIZE
     let depth = (number_of_elements as f32).log(max_size).ceil() as usize;
     // The number of elements each subtree will hold

--- a/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
+++ b/rstar/src/algorithm/bulk_load/cluster_group_iterator.rs
@@ -47,7 +47,7 @@ impl<T: RTreeObject> Iterator for ClusterGroupIterator<T> {
 /// Calculates the desired number of clusters on any axis
 ///
 /// A 'cluster' refers to a set of elements that will finally form an rtree node.
-pub fn calculate_number_of_clusters_on_axis<T>(params: &Params, number_of_elements: usize) -> usize
+pub fn calculate_number_of_clusters_on_axis<T>(params: Params, number_of_elements: usize) -> usize
 where
     T: RTreeObject,
 {

--- a/rstar/src/algorithm/rstar.rs
+++ b/rstar/src/algorithm/rstar.rs
@@ -1,22 +1,12 @@
 use crate::envelope::Envelope;
 use crate::node::{envelope_for_children, ParentNode, RTreeNode};
 use crate::object::RTreeObject;
-use crate::params::{InsertionStrategy, RTreeParams};
+use crate::params::Params;
 use crate::point::{Point, PointExt};
 use crate::rtree::RTree;
 
 use alloc::vec::Vec;
 use num_traits::{Bounded, Zero};
-
-/// Inserts points according to the r-star heuristic.
-///
-/// The r*-heuristic focusses on good insertion quality at the costs of
-/// insertion performance. This strategy is best for use cases with few
-/// insertions and many nearest neighbor queries.
-///
-/// `RStarInsertionStrategy` is used as the default insertion strategy.
-/// See [InsertionStrategy] for more information on insertion strategies.
-pub enum RStarInsertionStrategy {}
 
 enum InsertionResult<T>
 where
@@ -27,67 +17,73 @@ where
     Complete,
 }
 
-impl InsertionStrategy for RStarInsertionStrategy {
-    fn insert<T, Params>(tree: &mut RTree<T, Params>, t: T)
-    where
-        Params: RTreeParams,
-        T: RTreeObject,
-    {
-        use InsertionAction::*;
+/// Inserts points according to the r-star heuristic.
+///
+/// The r*-heuristic focusses on good insertion quality at the costs of
+/// insertion performance. This strategy is best for use cases with few
+/// insertions and many nearest neighbor queries.
+///
+/// `RStarInsertionStrategy` is used as the default insertion strategy.
+/// See [InsertionStrategy] for more information on insertion strategies.
+pub fn rstar_insert<T>(tree: &mut RTree<T>, t: T)
+where
+    T: RTreeObject,
+{
+    use InsertionAction::*;
 
-        enum InsertionAction<T: RTreeObject> {
-            PerformSplit(RTreeNode<T>),
-            PerformReinsert(RTreeNode<T>),
+    enum InsertionAction<T: RTreeObject> {
+        PerformSplit(RTreeNode<T>),
+        PerformReinsert(RTreeNode<T>),
+    }
+
+    let first = recursive_insert::<_>(&tree.params.clone(), tree.root_mut(), RTreeNode::Leaf(t), 0);
+    let mut target_height = 0;
+    let mut insertion_stack = Vec::new();
+    match first {
+        InsertionResult::Split(node) => insertion_stack.push(PerformSplit(node)),
+        InsertionResult::Reinsert(nodes_to_reinsert, real_target_height) => {
+            insertion_stack.extend(nodes_to_reinsert.into_iter().map(PerformReinsert));
+            target_height = real_target_height;
         }
+        InsertionResult::Complete => {}
+    };
 
-        let first = recursive_insert::<_, Params>(tree.root_mut(), RTreeNode::Leaf(t), 0);
-        let mut target_height = 0;
-        let mut insertion_stack = Vec::new();
-        match first {
-            InsertionResult::Split(node) => insertion_stack.push(PerformSplit(node)),
-            InsertionResult::Reinsert(nodes_to_reinsert, real_target_height) => {
-                insertion_stack.extend(nodes_to_reinsert.into_iter().map(PerformReinsert));
-                target_height = real_target_height;
+    while let Some(next) = insertion_stack.pop() {
+        match next {
+            PerformSplit(node) => {
+                // The root node was split, create a new root and increase height
+                let new_root = ParentNode::new_root(&tree.params);
+                let old_root = ::core::mem::replace(tree.root_mut(), new_root);
+                let new_envelope = old_root.envelope.merged(&node.envelope());
+                let root = tree.root_mut();
+                root.envelope = new_envelope;
+                root.children.push(RTreeNode::Parent(old_root));
+                root.children.push(node);
+                target_height += 1;
             }
-            InsertionResult::Complete => {}
-        };
-
-        while let Some(next) = insertion_stack.pop() {
-            match next {
-                PerformSplit(node) => {
-                    // The root node was split, create a new root and increase height
-                    let new_root = ParentNode::new_root::<Params>();
-                    let old_root = ::core::mem::replace(tree.root_mut(), new_root);
-                    let new_envelope = old_root.envelope.merged(&node.envelope());
-                    let root = tree.root_mut();
-                    root.envelope = new_envelope;
-                    root.children.push(RTreeNode::Parent(old_root));
-                    root.children.push(node);
-                    target_height += 1;
-                }
-                PerformReinsert(node_to_reinsert) => {
-                    let root = tree.root_mut();
-                    match forced_insertion::<T, Params>(root, node_to_reinsert, target_height) {
-                        InsertionResult::Split(node) => insertion_stack.push(PerformSplit(node)),
-                        InsertionResult::Reinsert(_, _) => {
-                            panic!("Unexpected reinsert. This is a bug in rstar.")
-                        }
-                        InsertionResult::Complete => {}
+            PerformReinsert(node_to_reinsert) => {
+                let params = tree.params.clone();
+                let root = tree.root_mut();
+                match forced_insertion::<T>(&params, root, node_to_reinsert, target_height) {
+                    InsertionResult::Split(node) => insertion_stack.push(PerformSplit(node)),
+                    InsertionResult::Reinsert(_, _) => {
+                        panic!("Unexpected reinsert. This is a bug in rstar.")
                     }
+                    InsertionResult::Complete => {}
                 }
             }
         }
     }
 }
 
-fn forced_insertion<T, Params>(
+fn forced_insertion<T>(
+    params: &Params,
     node: &mut ParentNode<T>,
     t: RTreeNode<T>,
     target_height: usize,
 ) -> InsertionResult<T>
 where
     T: RTreeObject,
-    Params: RTreeParams,
 {
     node.envelope.merge(&t.envelope());
     let expand_index = choose_subtree(node, &t);
@@ -95,15 +91,15 @@ where
     if target_height == 0 || node.children.len() < expand_index {
         // Force insertion into this node
         node.children.push(t);
-        return resolve_overflow_without_reinsertion::<_, Params>(node);
+        return resolve_overflow_without_reinsertion::<_>(params, node);
     }
 
     if let RTreeNode::Parent(ref mut follow) = node.children[expand_index] {
-        match forced_insertion::<_, Params>(follow, t, target_height - 1) {
+        match forced_insertion::<_>(params, follow, t, target_height - 1) {
             InsertionResult::Split(child) => {
                 node.envelope.merge(&child.envelope());
                 node.children.push(child);
-                resolve_overflow_without_reinsertion::<_, Params>(node)
+                resolve_overflow_without_reinsertion::<_>(params, node)
             }
             other => other,
         }
@@ -112,14 +108,14 @@ where
     }
 }
 
-fn recursive_insert<T, Params>(
+fn recursive_insert<T>(
+    params: &Params,
     node: &mut ParentNode<T>,
     t: RTreeNode<T>,
     current_height: usize,
 ) -> InsertionResult<T>
 where
     T: RTreeObject,
-    Params: RTreeParams,
 {
     node.envelope.merge(&t.envelope());
     let expand_index = choose_subtree(node, &t);
@@ -127,11 +123,11 @@ where
     if node.children.len() < expand_index {
         // Force insertion into this node
         node.children.push(t);
-        return resolve_overflow::<_, Params>(node, current_height);
+        return resolve_overflow::<_>(params, node, current_height);
     }
 
     let expand = if let RTreeNode::Parent(ref mut follow) = node.children[expand_index] {
-        recursive_insert::<_, Params>(follow, t, current_height + 1)
+        recursive_insert::<_>(params, follow, t, current_height + 1)
     } else {
         panic!("This is a bug in rstar.")
     };
@@ -140,7 +136,7 @@ where
         InsertionResult::Split(child) => {
             node.envelope.merge(&child.envelope());
             node.children.push(child);
-            resolve_overflow::<_, Params>(node, current_height)
+            resolve_overflow::<_>(params, node, current_height)
         }
         InsertionResult::Reinsert(a, b) => {
             node.envelope = envelope_for_children(&node.children);
@@ -220,46 +216,50 @@ where
 }
 
 // Never returns a request for reinsertion
-fn resolve_overflow_without_reinsertion<T, Params>(node: &mut ParentNode<T>) -> InsertionResult<T>
+fn resolve_overflow_without_reinsertion<T>(
+    params: &Params,
+    node: &mut ParentNode<T>,
+) -> InsertionResult<T>
 where
     T: RTreeObject,
-    Params: RTreeParams,
 {
-    if node.children.len() > Params::MAX_SIZE {
-        let off_split = split::<_, Params>(node);
+    if node.children.len() > params.max_size() {
+        let off_split = split::<_>(params, node);
         InsertionResult::Split(off_split)
     } else {
         InsertionResult::Complete
     }
 }
 
-fn resolve_overflow<T, Params>(node: &mut ParentNode<T>, current_depth: usize) -> InsertionResult<T>
+fn resolve_overflow<T>(
+    params: &Params,
+    node: &mut ParentNode<T>,
+    current_depth: usize,
+) -> InsertionResult<T>
 where
     T: RTreeObject,
-    Params: RTreeParams,
 {
-    if Params::REINSERTION_COUNT == 0 {
-        resolve_overflow_without_reinsertion::<_, Params>(node)
-    } else if node.children.len() > Params::MAX_SIZE {
-        let nodes_for_reinsertion = get_nodes_for_reinsertion::<_, Params>(node);
+    if params.reinsertion_count() == 0 {
+        resolve_overflow_without_reinsertion::<_>(params, node)
+    } else if node.children.len() > params.max_size() {
+        let nodes_for_reinsertion = get_nodes_for_reinsertion::<_>(params, node);
         InsertionResult::Reinsert(nodes_for_reinsertion, current_depth)
     } else {
         InsertionResult::Complete
     }
 }
 
-fn split<T, Params>(node: &mut ParentNode<T>) -> RTreeNode<T>
+fn split<T>(params: &Params, node: &mut ParentNode<T>) -> RTreeNode<T>
 where
     T: RTreeObject,
-    Params: RTreeParams,
 {
-    let axis = get_split_axis::<_, Params>(node);
+    let axis = get_split_axis::<_>(params, node);
     let zero = <<T::Envelope as Envelope>::Point as Point>::Scalar::zero();
     debug_assert!(node.children.len() >= 2);
     // Sort along axis
     T::Envelope::sort_envelopes(axis, &mut node.children);
     let mut best = (zero, zero);
-    let min_size = Params::MIN_SIZE;
+    let min_size = params.min_size();
     let mut best_index = min_size;
 
     for k in min_size..=node.children.len() - min_size {
@@ -286,14 +286,13 @@ where
     RTreeNode::Parent(ParentNode::new_parent(off_split))
 }
 
-fn get_split_axis<T, Params>(node: &mut ParentNode<T>) -> usize
+fn get_split_axis<T>(params: &Params, node: &mut ParentNode<T>) -> usize
 where
     T: RTreeObject,
-    Params: RTreeParams,
 {
     let mut best_goodness = <<T::Envelope as Envelope>::Point as Point>::Scalar::max_value();
     let mut best_axis = 0;
-    let min_size = Params::MIN_SIZE;
+    let min_size = params.min_size();
     let until = node.children.len() - min_size + 1;
     for axis in 0..<T::Envelope as Envelope>::Point::DIMENSIONS {
         // Sort children along the current axis
@@ -328,10 +327,9 @@ where
     best_axis
 }
 
-fn get_nodes_for_reinsertion<T, Params>(node: &mut ParentNode<T>) -> Vec<RTreeNode<T>>
+fn get_nodes_for_reinsertion<T>(params: &Params, node: &mut ParentNode<T>) -> Vec<RTreeNode<T>>
 where
     T: RTreeObject,
-    Params: RTreeParams,
 {
     let center = node.envelope.center();
     // Sort with increasing order so we can use Vec::split_off
@@ -347,7 +345,7 @@ where
     let num_children = node.children.len();
     let result = node
         .children
-        .split_off(num_children - Params::REINSERTION_COUNT);
+        .split_off(num_children - params.reinsertion_count());
     node.envelope = envelope_for_children(&node.children);
     result
 }

--- a/rstar/src/algorithm/rstar.rs
+++ b/rstar/src/algorithm/rstar.rs
@@ -36,7 +36,8 @@ where
         PerformReinsert(RTreeNode<T>),
     }
 
-    let first = recursive_insert::<_>(&tree.params.clone(), tree.root_mut(), RTreeNode::Leaf(t), 0);
+    let params = tree.params.clone();
+    let first = recursive_insert::<_>(params, tree.root_mut(), RTreeNode::Leaf(t), 0);
     let mut target_height = 0;
     let mut insertion_stack = Vec::new();
     match first {
@@ -52,7 +53,7 @@ where
         match next {
             PerformSplit(node) => {
                 // The root node was split, create a new root and increase height
-                let new_root = ParentNode::new_root(&tree.params);
+                let new_root = ParentNode::new_root(tree.params);
                 let old_root = ::core::mem::replace(tree.root_mut(), new_root);
                 let new_envelope = old_root.envelope.merged(&node.envelope());
                 let root = tree.root_mut();
@@ -62,9 +63,8 @@ where
                 target_height += 1;
             }
             PerformReinsert(node_to_reinsert) => {
-                let params = tree.params.clone();
                 let root = tree.root_mut();
-                match forced_insertion::<T>(&params, root, node_to_reinsert, target_height) {
+                match forced_insertion::<T>(params, root, node_to_reinsert, target_height) {
                     InsertionResult::Split(node) => insertion_stack.push(PerformSplit(node)),
                     InsertionResult::Reinsert(_, _) => {
                         panic!("Unexpected reinsert. This is a bug in rstar.")
@@ -77,7 +77,7 @@ where
 }
 
 fn forced_insertion<T>(
-    params: &Params,
+    params: Params,
     node: &mut ParentNode<T>,
     t: RTreeNode<T>,
     target_height: usize,
@@ -109,7 +109,7 @@ where
 }
 
 fn recursive_insert<T>(
-    params: &Params,
+    params: Params,
     node: &mut ParentNode<T>,
     t: RTreeNode<T>,
     current_height: usize,
@@ -217,7 +217,7 @@ where
 
 // Never returns a request for reinsertion
 fn resolve_overflow_without_reinsertion<T>(
-    params: &Params,
+    params: Params,
     node: &mut ParentNode<T>,
 ) -> InsertionResult<T>
 where
@@ -232,7 +232,7 @@ where
 }
 
 fn resolve_overflow<T>(
-    params: &Params,
+    params: Params,
     node: &mut ParentNode<T>,
     current_depth: usize,
 ) -> InsertionResult<T>
@@ -249,7 +249,7 @@ where
     }
 }
 
-fn split<T>(params: &Params, node: &mut ParentNode<T>) -> RTreeNode<T>
+fn split<T>(params: Params, node: &mut ParentNode<T>) -> RTreeNode<T>
 where
     T: RTreeObject,
 {
@@ -286,7 +286,7 @@ where
     RTreeNode::Parent(ParentNode::new_parent(off_split))
 }
 
-fn get_split_axis<T>(params: &Params, node: &mut ParentNode<T>) -> usize
+fn get_split_axis<T>(params: Params, node: &mut ParentNode<T>) -> usize
 where
     T: RTreeObject,
 {
@@ -327,7 +327,7 @@ where
     best_axis
 }
 
-fn get_nodes_for_reinsertion<T>(params: &Params, node: &mut ParentNode<T>) -> Vec<RTreeNode<T>>
+fn get_nodes_for_reinsertion<T>(params: Params, node: &mut ParentNode<T>) -> Vec<RTreeNode<T>>
 where
     T: RTreeObject,
 {

--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -39,12 +39,11 @@ mod rtree;
 mod test_utilities;
 
 pub use crate::aabb::AABB;
-pub use crate::algorithm::rstar::RStarInsertionStrategy;
 pub use crate::algorithm::selection_functions::SelectionFunction;
 pub use crate::envelope::Envelope;
 pub use crate::node::{ParentNode, RTreeNode};
 pub use crate::object::{PointDistance, RTreeObject};
-pub use crate::params::{DefaultParams, InsertionStrategy, RTreeParams};
+pub use crate::params::Params;
 pub use crate::point::{Point, RTreeNum};
 pub use crate::rtree::RTree;
 

--- a/rstar/src/node.rs
+++ b/rstar/src/node.rs
@@ -85,7 +85,7 @@ where
         self.envelope
     }
 
-    pub(crate) fn new_root(params: &Params) -> Self {
+    pub(crate) fn new_root(params: Params) -> Self {
         ParentNode {
             envelope: Envelope::new_empty(),
             children: Vec::with_capacity(params.max_size() + 1),

--- a/rstar/src/params.rs
+++ b/rstar/src/params.rs
@@ -41,9 +41,12 @@ impl Default for Params {
 
 impl Params {
     /// hi
-    pub fn new(min_size: usize, max_size: usize, reinsertion_count: usize) -> Self {
+    pub const fn new(min_size: usize, max_size: usize, reinsertion_count: usize) -> Self {
         // FIXME: add an Error enum and make this function return
         // Result<Self, rstar::Error> instead of asserting....
+
+        // If we don't want to do that, to make this const, we could
+        // use the `const_format` crate....
         assert!(max_size >= 4, "MAX_SIZE too small. Must be larger than 4.");
 
         assert!(min_size > 0, "MIN_SIZE must be at least 1",);

--- a/rstar/src/params.rs
+++ b/rstar/src/params.rs
@@ -1,5 +1,3 @@
-use crate::{Envelope, Point, RTreeObject};
-
 /// Defines static parameters for an r-tree.
 ///
 /// Internally, an r-tree contains several nodes, similar to a b-tree. These parameters change
@@ -44,6 +42,25 @@ impl Default for Params {
 impl Params {
     /// hi
     pub fn new(min_size: usize, max_size: usize, reinsertion_count: usize) -> Self {
+        // FIXME: add an Error enum and make this function return
+        // Result<Self, rstar::Error> instead of asserting....
+        assert!(max_size >= 4, "MAX_SIZE too small. Must be larger than 4.");
+
+        assert!(min_size > 0, "MIN_SIZE must be at least 1",);
+        let max_min_size = (max_size + 1) / 2;
+        assert!(
+            min_size <= max_min_size,
+            "MIN_SIZE too large. Must be less or equal to {:?}",
+            max_min_size
+        );
+
+        let max_reinsertion_count = max_size - min_size;
+        assert!(
+            reinsertion_count < max_reinsertion_count,
+            "REINSERTION_COUNT too large. Must be smaller than {:?}",
+            max_reinsertion_count
+        );
+
         Params {
             min_size,
             max_size,
@@ -64,34 +81,5 @@ impl Params {
     /// hi
     pub fn reinsertion_count(&self) -> usize {
         self.reinsertion_count
-    }
-
-    /// hi
-    pub fn check<T: RTreeObject>(&self) {
-        assert!(
-            self.max_size() >= 4,
-            "MAX_SIZE too small. Must be larger than 4."
-        );
-
-        assert!(self.min_size() > 0, "MIN_SIZE must be at least 1",);
-        let max_min_size = (self.max_size() + 1) / 2;
-        assert!(
-            self.min_size() <= max_min_size,
-            "MIN_SIZE too large. Must be less or equal to {:?}",
-            max_min_size
-        );
-
-        let max_reinsertion_count = self.max_size() - self.min_size();
-        assert!(
-            self.reinsertion_count() < max_reinsertion_count,
-            "REINSERTION_COUNT too large. Must be smaller than {:?}",
-            max_reinsertion_count
-        );
-
-        let dimension = <T::Envelope as Envelope>::Point::DIMENSIONS;
-        assert!(
-            dimension > 1,
-            "Point dimension too small - must be at least 2"
-        );
     }
 }

--- a/rstar/src/params.rs
+++ b/rstar/src/params.rs
@@ -41,7 +41,7 @@ impl Default for Params {
 
 impl Params {
     /// hi
-    pub const fn new(min_size: usize, max_size: usize, reinsertion_count: usize) -> Self {
+    pub fn new(min_size: usize, max_size: usize, reinsertion_count: usize) -> Self {
         // FIXME: add an Error enum and make this function return
         // Result<Self, rstar::Error> instead of asserting....
 

--- a/rstar/src/params.rs
+++ b/rstar/src/params.rs
@@ -1,5 +1,4 @@
-use crate::algorithm::rstar::RStarInsertionStrategy;
-use crate::{Envelope, Point, RTree, RTreeObject};
+use crate::{Envelope, Point, RTreeObject};
 
 /// Defines static parameters for an r-tree.
 ///
@@ -8,109 +7,91 @@ use crate::{Envelope, Point, RTree, RTreeObject};
 ///
 /// # Example
 /// ```
-/// use rstar::{RTreeParams, RTree, RStarInsertionStrategy};
-///
+/// use rstar::{Params, RTree};
 /// // This example uses an rtree with larger internal nodes.
-/// struct LargeNodeParameters;
-///
-/// impl RTreeParams for LargeNodeParameters
-/// {
-///     const MIN_SIZE: usize = 10;
-///     const MAX_SIZE: usize = 30;
-///     const REINSERTION_COUNT: usize = 5;
-///     type DefaultInsertionStrategy = RStarInsertionStrategy;
-/// }
-///
-/// // Optional but helpful: Define a type alias for the new r-tree
-/// type LargeNodeRTree<T> = RTree<T, LargeNodeParameters>;
 ///
 /// # fn main() {
 /// // The only difference from now on is the usage of "new_with_params" instead of "new"
-/// let mut large_node_tree: LargeNodeRTree<_> = RTree::new_with_params();
+/// let params = Params::new(10, 30, 5);
+/// let mut large_node_tree: RTree<_> = RTree::new_with_params(params.clone());
 /// // Using the r-tree should allow inference for the point type
 /// large_node_tree.insert([1.0, -1.0f32]);
 /// // There is also a bulk load method with parameters:
 /// # let some_elements = vec![[0.0, 0.0]];
-/// let tree: LargeNodeRTree<_> = RTree::bulk_load_with_params(some_elements);
+/// let tree: RTree<_> = RTree::bulk_load_with_params(params, some_elements);
 /// # }
 /// ```
-pub trait RTreeParams: Send + Sync {
-    /// The minimum size of an internal node. `MIN_SIZE` must be greater than zero, and up to half
-    /// as large as `MAX_SIZE`.
-    ///
-    /// Choosing a value around one half or one third of `MAX_SIZE` is recommended. Larger values
-    /// should yield slightly better tree quality, while lower values may benefit insertion
-    /// performance.
-    const MIN_SIZE: usize;
 
-    /// The maximum size of an internal node. Larger values will improve insertion performance
-    /// but increase the average query time.
-    const MAX_SIZE: usize;
-
-    /// The number of nodes that the insertion strategy tries to occasionally reinsert to
-    /// maintain a good tree quality. Must be smaller than `MAX_SIZE` - `MIN_SIZE`.
-    /// Larger values will improve query times but increase insertion time.
-    const REINSERTION_COUNT: usize;
-
-    /// The insertion strategy which is used when calling [RTree::insert].
-    type DefaultInsertionStrategy: InsertionStrategy;
-}
-
-/// The default parameters used when creating an r-tree without specific parameters.
+/// hi
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 #[derive(Clone, Copy, PartialEq, Eq)]
-pub struct DefaultParams;
-
-impl RTreeParams for DefaultParams {
-    const MIN_SIZE: usize = 3;
-    const MAX_SIZE: usize = 6;
-    const REINSERTION_COUNT: usize = 2;
-    type DefaultInsertionStrategy = RStarInsertionStrategy;
+pub struct Params {
+    min_size: usize,
+    max_size: usize,
+    reinsertion_count: usize,
 }
 
-/// Defines how points are inserted into an r-tree.
-///
-/// Different strategies try to minimize both _insertion time_ (how long does it take to add a new
-/// object into the tree?) and _querying time_ (how long does an average nearest neighbor query
-/// take?).
-/// Currently, only one insertion strategy is implemented: R* (R-star) insertion. R* insertion
-/// tries to minimize querying performance while yielding reasonable insertion times, making it a
-/// good default strategy. More strategies may be implemented in the future.
-///
-/// Only calls to [RTree::insert] are affected by this strategy.
-///
-/// This trait is not meant to be implemented by the user.
-pub trait InsertionStrategy {
-    #[doc(hidden)]
-    fn insert<T, Params>(tree: &mut RTree<T, Params>, t: T)
-    where
-        Params: RTreeParams,
-        T: RTreeObject;
+impl Default for Params {
+    fn default() -> Self {
+        Self {
+            min_size: 3,
+            max_size: 6,
+            reinsertion_count: 2,
+        }
+    }
 }
 
-pub fn verify_parameters<T: RTreeObject, P: RTreeParams>() {
-    assert!(
-        P::MAX_SIZE >= 4,
-        "MAX_SIZE too small. Must be larger than 4."
-    );
+impl Params {
+    /// hi
+    pub fn new(min_size: usize, max_size: usize, reinsertion_count: usize) -> Self {
+        Params {
+            min_size,
+            max_size,
+            reinsertion_count,
+        }
+    }
 
-    assert!(P::MIN_SIZE > 0, "MIN_SIZE must be at least 1",);
-    let max_min_size = (P::MAX_SIZE + 1) / 2;
-    assert!(
-        P::MIN_SIZE <= max_min_size,
-        "MIN_SIZE too large. Must be less or equal to {:?}",
-        max_min_size
-    );
+    /// hi
+    pub fn min_size(&self) -> usize {
+        self.min_size
+    }
 
-    let max_reinsertion_count = P::MAX_SIZE - P::MIN_SIZE;
-    assert!(
-        P::REINSERTION_COUNT < max_reinsertion_count,
-        "REINSERTION_COUNT too large. Must be smaller than {:?}",
-        max_reinsertion_count
-    );
+    /// hi
+    pub fn max_size(&self) -> usize {
+        self.max_size
+    }
 
-    let dimension = <T::Envelope as Envelope>::Point::DIMENSIONS;
-    assert!(
-        dimension > 1,
-        "Point dimension too small - must be at least 2"
-    );
+    /// hi
+    pub fn reinsertion_count(&self) -> usize {
+        self.reinsertion_count
+    }
+
+    /// hi
+    pub fn check<T: RTreeObject>(&self) {
+        assert!(
+            self.max_size() >= 4,
+            "MAX_SIZE too small. Must be larger than 4."
+        );
+
+        assert!(self.min_size() > 0, "MIN_SIZE must be at least 1",);
+        let max_min_size = (self.max_size() + 1) / 2;
+        assert!(
+            self.min_size() <= max_min_size,
+            "MIN_SIZE too large. Must be less or equal to {:?}",
+            max_min_size
+        );
+
+        let max_reinsertion_count = self.max_size() - self.min_size();
+        assert!(
+            self.reinsertion_count() < max_reinsertion_count,
+            "REINSERTION_COUNT too large. Must be smaller than {:?}",
+            max_reinsertion_count
+        );
+
+        let dimension = <T::Envelope as Envelope>::Point::DIMENSIONS;
+        assert!(
+            dimension > 1,
+            "Point dimension too small - must be at least 2"
+        );
+    }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---
Hi! This PR makes `RTree` parameters a single struct, named `Params` instead of a trait that clients have to provide as part of the type signature. I need that functionality for a project I'm working where the parameters have to be supplied externally and can't be baked into code statically -- we're experimenting with using RTrees for partitioning rather than lookups.

This change produces a 3%-15% improvement on benchmarks.

Along the way, I've moved some checks into `Params::new` or into a static assert (in the case of the point dimension greater than 1 check).

Although I made this PR to provide more flexibility to clients and although it has improved benchmarks, I think this change has made the API simpler as well. `Params` is just a single struct with a constructor. You don't have to deal with weird type magic. `RTree<T>` has a single generic parameter, `T`. In earlier versions of this PR, I made the insertion strategy another generic parameter for `RTree` with a default value, but then dropped it because it cluttered up the code significantly; this crate is almost 5 years old and has only ever had one insertion strategy, so I didn't see the benefit in adding another generic parameter to support genericity that we haven't needed and are unlikely to need in the future.

Tests and benchmarks pass but I still need to clean up the docs.