### PR TITLE
perf: minimize iterations over children in `IntersectionIterator`

### DIFF
--- a/rstar/src/algorithm/intersection_iterator.rs
+++ b/rstar/src/algorithm/intersection_iterator.rs
@@ -50,13 +50,14 @@ where
             .iter()
             .filter(|c1| c1.envelope().intersects(&parent2.envelope()));
 
-        for child1 in children1 {
-            let children2 = parent2
-                .children()
-                .iter()
-                .filter(|c2| c2.envelope().intersects(&parent1.envelope()));
+        let children2: Vec<&RTreeNode<U>> = parent2
+            .children()
+            .iter()
+            .filter(|c2| c2.envelope().intersects(&parent1.envelope()))
+            .collect();
 
-            for child2 in children2 {
+        for child1 in children1 {
+            for child2 in &children2 {
                 self.push_if_intersecting(child1, child2);
             }
         }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

I was reading through the code and noticed that this was a double for loop, but `children2` doesn't depend on `child1` at all, so it doesn't need to be in the for loop. You do have to collect the items into a vector because you can't use the iterator more than once, but seems better than recomputing it every loop iteration?