### PR TITLE
Impl Point for [RTreeNum; N] const generic N

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -11,6 +11,7 @@
 ## Added
 - Added method `RTree::drain()`.
 - Changed license field to [SPDX 2.1 license expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60)
+- `Point` is now implemented as const generic for any length of `RTreeNum` array
 
 ## Changed
 - fixed all clippy lint issues

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 - Add `CachedEnvelope` combinator which simplifies memoizing envelope computations. ([PR](https://github.com/georust/rstar/pull/118))
+- `Point` is now implemented as const generic for any length of `RTreeNum` array
 
 ## Changed
 - Increase our MSRV to Rust 1.63 following that of the `geo` crate.  ([PR](https://github.com/georust/rstar/pull/124))
@@ -11,7 +12,6 @@
 ## Added
 - Added method `RTree::drain()`.
 - Changed license field to [SPDX 2.1 license expression](https://spdx.dev/spdx-specification-21-web-version/#h.jxpfx0ykyb60)
-- `Point` is now implemented as const generic for any length of `RTreeNum` array
 
 ## Changed
 - fixed all clippy lint issues

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -304,48 +304,41 @@ where
     }
 }
 
+impl<S, const N: usize> Point for [S; N]
+where
+    S: RTreeNum,
+{
+    type Scalar = S;
+
+    const DIMENSIONS: usize = N;
+
+    fn generate(mut generator: impl FnMut(usize) -> S) -> Self {
+        // The same implementation used in std::array::from_fn
+        // Since this is a const generic it gets unrolled
+        let mut idx = 0;
+        [(); N].map(|_| {
+            let res = generator(idx);
+            idx += 1;
+            res
+        })
+    }
+
+    #[inline]
+    fn nth(&self, index: usize) -> Self::Scalar {
+        self[index]
+    }
+
+    #[inline]
+    fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
+        &mut self[index]
+    }
+}
+
 macro_rules! count_exprs {
     () => (0);
     ($head:expr) => (1);
     ($head:expr, $($tail:expr),*) => (1 + count_exprs!($($tail),*));
 }
-
-macro_rules! implement_point_for_array {
-    ($($index:expr),*) => {
-        impl<S> Point for [S; count_exprs!($($index),*)]
-        where
-            S: RTreeNum,
-        {
-            type Scalar = S;
-
-            const DIMENSIONS: usize = count_exprs!($($index),*);
-
-            fn generate(mut generator: impl FnMut(usize) -> S) -> Self
-            {
-                [$(generator($index)),*]
-            }
-
-            #[inline]
-            fn nth(&self, index: usize) -> Self::Scalar {
-                self[index]
-            }
-
-            #[inline]
-            fn nth_mut(&mut self, index: usize) -> &mut Self::Scalar {
-                &mut self[index]
-            }
-        }
-    };
-}
-
-implement_point_for_array!(0, 1);
-implement_point_for_array!(0, 1, 2);
-implement_point_for_array!(0, 1, 2, 3);
-implement_point_for_array!(0, 1, 2, 3, 4);
-implement_point_for_array!(0, 1, 2, 3, 4, 5);
-implement_point_for_array!(0, 1, 2, 3, 4, 5, 6);
-implement_point_for_array!(0, 1, 2, 3, 4, 5, 6, 7);
-implement_point_for_array!(0, 1, 2, 3, 4, 5, 6, 7, 8);
 
 macro_rules! fixed_type {
     ($expr:expr, $type:ty) => {


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Point is now implemented for `[RTreeNum; N]` where `N` is a `usize`. Previously it was only for N values between 2 and 9. Const generics are stable in every supported version of Rust.