### PR TITLE
RFC: Use extension trait to simplify combinator usage.

### DIFF
--- a/rstar/src/lib.rs
+++ b/rstar/src/lib.rs
@@ -43,7 +43,7 @@ pub use crate::algorithm::rstar::RStarInsertionStrategy;
 pub use crate::algorithm::selection_functions::SelectionFunction;
 pub use crate::envelope::Envelope;
 pub use crate::node::{ParentNode, RTreeNode};
-pub use crate::object::{PointDistance, RTreeObject};
+pub use crate::object::{PointDistance, RTreeObject, RTreeObjectExt};
 pub use crate::params::{DefaultParams, InsertionStrategy, RTreeParams};
 pub use crate::point::{Point, RTreeNum};
 pub use crate::rtree::RTree;

--- a/rstar/src/object.rs
+++ b/rstar/src/object.rs
@@ -1,6 +1,7 @@
 use crate::aabb::AABB;
 use crate::envelope::Envelope;
 use crate::point::{Point, PointExt};
+use crate::primitives::{CachedEnvelope, GeomWithData};
 
 /// An object that can be inserted into an r-tree.
 ///
@@ -223,5 +224,37 @@ where
         } else {
             None
         }
+    }
+}
+
+/// TODO
+pub trait RTreeObjectExt: RTreeObject {
+    /// TODO
+    fn with_data<S>(self, data: S) -> GeomWithData<Self, S>
+    where
+        Self: Sized;
+
+    /// TODO
+    fn cached_envelope(self) -> CachedEnvelope<Self>
+    where
+        Self: Sized;
+}
+
+impl<T> RTreeObjectExt for T
+where
+    T: RTreeObject,
+{
+    fn with_data<S>(self, data: S) -> GeomWithData<Self, S>
+    where
+        Self: Sized,
+    {
+        GeomWithData::new(self, data)
+    }
+
+    fn cached_envelope(self) -> CachedEnvelope<Self>
+    where
+        Self: Sized,
+    {
+        CachedEnvelope::new(self)
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Not sure if this is worth the extra boiler plate, but it would be consistent with how e.g. std's `Iterator`-related combinators are typically accessed. 
