### PR TITLE
Fix a stack overflow error in DrainIterator

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Changed
+- Fixed a stack overflow error in `DrainIterator::next`
+
 # 0.11.0
 
 ## Added

--- a/rstar/src/algorithm/removal.rs
+++ b/rstar/src/algorithm/removal.rs
@@ -129,7 +129,7 @@ where
     type Item = T;
 
     fn next(&mut self) -> Option<Self::Item> {
-        loop {
+        'attempt_loop: loop {
             // Get reference to top node or return None.
             let (node, idx, remove_count) = match self.node_stack.last_mut() {
                 Some(node) => (&mut node.0, &mut node.1, &mut node.2),
@@ -149,7 +149,7 @@ where
                                 RTreeNode::Parent(node) => node,
                             };
                             self.node_stack.push((child, 0, 0));
-                            return self.next();
+                            continue 'attempt_loop;
                         }
                         RTreeNode::Leaf(ref leaf) => {
                             if self.removal_function.should_unpack_leaf(leaf) {


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Fixes a stack overflow error when using `RTree::drain_with_selection_function` or any other method that uses `DrainIterator`.