### PR TITLE
Update rstar-benches geo dependency

### DIFF
--- a/rstar-benches/Cargo.toml
+++ b/rstar-benches/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Stefan Altmayer <stoeoef@gmail.com>", "The Georust Developers <mods@
 
 [dev-dependencies]
 criterion = { version = "0.4.0", features = ["html_reports"] }
-geo = "0.24.1"
+geo = "0.26.0"
 geo-types = { version = "0.7.9", features = ["use-rstar_0_10"] }
 rand = "0.7"
 rand_hc = "0.2"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This fixes an error like:

error[E0275]: overflow evaluating the requirement
`~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/geo-0.24.1/src/algorithm/map_coords.rs:855:69:
855:72]: Fn<(geo_types::Coord<T>,)>`

