### PR TITLE
Use unstable sort for envelopes and node reinsertion

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Changed
+- Switched to unstable sort for envelopes and node reinsertion ([PR](https://github.com/georust/rstar/pull/160))
+
 # 0.12.0
 
 ## Added

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -195,7 +195,7 @@ where
     }
 
     fn sort_envelopes<T: RTreeObject<Envelope = Self>>(axis: usize, envelopes: &mut [T]) {
-        envelopes.sort_by(|l, r| {
+        envelopes.sort_unstable_by(|l, r| {
             l.envelope()
                 .lower
                 .nth(axis)

--- a/rstar/src/algorithm/rstar.rs
+++ b/rstar/src/algorithm/rstar.rs
@@ -335,7 +335,7 @@ where
 {
     let center = node.envelope.center();
     // Sort with increasing order so we can use Vec::split_off
-    node.children.sort_by(|l, r| {
+    node.children.sort_unstable_by(|l, r| {
         let l_center = l.envelope().center();
         let r_center = r.envelope().center();
         l_center


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

I was just looking at some unrelated AABB performance testing and noticed stable sort being used in a couple places.

I don't have a great performance/memory profile to show a meaningful difference here, but there doesn't seem to be a reason we need to stable sort in these places.

(probably not worth a changelog entry)