### PR TITLE
RFC: Provide selection methods based on internal iteration

### DIFF
--- a/rstar-benches/Cargo.toml
+++ b/rstar-benches/Cargo.toml
@@ -4,11 +4,11 @@ version = "0.1.1"
 authors = ["Stefan Altmayer <stoeoef@gmail.com>", "The Georust Developers <mods@georust.org>"]
 
 [dev-dependencies]
-criterion = { version = "0.4.0", features = ["html_reports"] }
-geo = "0.26.0"
-geo-types = { version = "0.7.9", features = ["use-rstar_0_10"] }
-rand = "0.7"
-rand_hc = "0.2"
+criterion = { version = "0.5.0", features = ["html_reports"] }
+geo = "0.28.0"
+geo-types = { version = "0.7.9", features = ["use-rstar_0_12"] }
+rand = "0.8"
+rand_hc = "0.3"
 rstar = { path = "../rstar" }
 
 [[bench]]

--- a/rstar-benches/benches/benchmarks.rs
+++ b/rstar-benches/benches/benchmarks.rs
@@ -123,6 +123,24 @@ fn locate_unsuccessful(c: &mut Criterion) {
     });
 }
 
+fn locate_successful_internal(c: &mut Criterion) {
+    let points: Vec<_> = create_random_points(100_000, SEED_1);
+    let query_point = points[500];
+    let tree = RTree::<_, Params>::bulk_load_with_params(points);
+    c.bench_function("locate_at_point_int (successful)", move |b| {
+        b.iter(|| tree.locate_at_point_int(&query_point).is_some())
+    });
+}
+
+fn locate_unsuccessful_internal(c: &mut Criterion) {
+    let points: Vec<_> = create_random_points(100_000, SEED_1);
+    let tree = RTree::<_, Params>::bulk_load_with_params(points);
+    let query_point = [0.7, 0.7];
+    c.bench_function("locate_at_point_int (unsuccessful)", move |b| {
+        b.iter(|| tree.locate_at_point(&query_point).is_none())
+    });
+}
+
 criterion_group!(
     benches,
     bulk_load_baseline,
@@ -131,7 +149,9 @@ criterion_group!(
     bulk_load_complex_geom_cached,
     tree_creation_quality,
     locate_successful,
-    locate_unsuccessful
+    locate_unsuccessful,
+    locate_successful_internal,
+    locate_unsuccessful_internal,
 );
 criterion_main!(benches);
 

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -332,6 +332,38 @@ where
         )
     }
 
+    /// Variant of [`locate_in_envelope`][Self::locate_in_envelope] using internal iteration.
+    pub fn locate_in_envelope_int<'a, V, B>(
+        &'a self,
+        envelope: &T::Envelope,
+        mut visitor: V,
+    ) -> ControlFlow<B>
+    where
+        V: FnMut(&'a T) -> ControlFlow<B>,
+    {
+        select_nodes(
+            self.root(),
+            &SelectInEnvelopeFunction::new(envelope.clone()),
+            &mut visitor,
+        )
+    }
+
+    /// Mutable variant of [`locate_in_envelope_mut`][Self::locate_in_envelope_mut].
+    pub fn locate_in_envelope_int_mut<'a, V, B>(
+        &'a mut self,
+        envelope: &T::Envelope,
+        mut visitor: V,
+    ) -> ControlFlow<B>
+    where
+        V: FnMut(&'a mut T) -> ControlFlow<B>,
+    {
+        select_nodes_mut(
+            self.root_mut(),
+            &SelectInEnvelopeFunction::new(envelope.clone()),
+            &mut visitor,
+        )
+    }
+
     /// Returns a draining iterator over all elements contained in the tree.
     ///
     /// The order in which the elements are returned is not specified.
@@ -405,6 +437,38 @@ where
         LocateInEnvelopeIntersectingMut::new(
             &mut self.root,
             SelectInEnvelopeFuncIntersecting::new(envelope.clone()),
+        )
+    }
+
+    /// Variant of [`locate_in_envelope_intersecting`][Self::locate_in_envelope_intersecting] using internal iteration.
+    pub fn locate_in_envelope_intersecting_int<'a, V, B>(
+        &'a self,
+        envelope: &T::Envelope,
+        mut visitor: V,
+    ) -> ControlFlow<B>
+    where
+        V: FnMut(&'a T) -> ControlFlow<B>,
+    {
+        select_nodes(
+            self.root(),
+            &SelectInEnvelopeFuncIntersecting::new(envelope.clone()),
+            &mut visitor,
+        )
+    }
+
+    /// Mutable variant of [`locate_in_envelope_intersecting_int`][Self::locate_in_envelope_intersecting_int].
+    pub fn locate_in_envelope_intersecting_int_mut<'a, V, B>(
+        &'a mut self,
+        envelope: &T::Envelope,
+        mut visitor: V,
+    ) -> ControlFlow<B>
+    where
+        V: FnMut(&'a mut T) -> ControlFlow<B>,
+    {
+        select_nodes_mut(
+            self.root_mut(),
+            &SelectInEnvelopeFuncIntersecting::new(envelope.clone()),
+            &mut visitor,
         )
     }
 

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -95,6 +95,18 @@ where
 /// A naive sequential algorithm would take `O(n)` time. However, r-trees incur higher
 /// build up times: inserting an element into an r-tree costs `O(log(n))` time.
 ///
+/// Most of the selection methods, meaning those with names beginning with `locate_`,
+/// return iterators which are driven externally and can therefore be combined into
+/// more complex pipelines using the combinators defined on the [`Iterator`] trait.
+///
+/// This flexiblity does come at the cost of temporary heap allocations required
+/// to keep track of the iteration state. Alternative methods using internal iteration
+/// are provided to avoid this overhead, their names ending in `_int` or `_int_mut`.
+///
+/// They use a callback-based interface to pass the selected objects on to the caller
+/// thereby being able to use the stack to keep track of the state required for
+/// traversing the tree.
+///
 /// # Bulk loading
 /// In many scenarios, insertion is only carried out once for many points. In this case,
 /// [RTree::bulk_load] will be considerably faster. Its total run time


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This avoids the overhead of allocating an internal buffer to keep track of upcoming nodes when implementing the `Iterator` trait.

I also found a mistake in the old code from #37 (lack of early return in the parent case) and now the benchmarks also look somewhat nicer, i.e. directly comparing internal and external iteration on the same data set:

```console
locate_at_point (successful)
                        time:   [115.62 ns 116.51 ns 117.43 ns]

locate_at_point_int (successful)
                        time:   [66.831 ns 67.264 ns 67.653 ns]

locate_at_point (unsuccessful)
                        time:   [167.70 ns 168.03 ns 168.34 ns]

locate_at_point_int (unsuccessful)
                        time:   [167.90 ns 168.28 ns 168.64 ns]
```

Closes #163 