### PR TITLE
Update smallvec

### DIFF
--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -19,7 +19,7 @@ maintenance = { status = "actively-developed" }
 heapless = "0.8"
 num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
-smallvec = "1.6"
+smallvec = "1.13"
 mint = { version = "0.5.9", optional = true }
 
 [features]


### PR DESCRIPTION
I'm having build conflicts when I include both `rstar` and another crate using new `smallvec`. Any reason the version specified in rstar is so old? Tests pass just fine with this change, but I haven't looked at any benchmarks yet. May also be related to #163.

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.