### PR TITLE
Allow 1D `RTree`s

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Switched to unstable sort for envelopes and node reinsertion ([PR](https://github.com/georust/rstar/pull/160))
 - Use a more tame value for `AABB::new_empty` to avoid overflow panics applying selections on empty trees ([PR](https://github.com/georust/rstar/pull/162))
 - Avoid infinite recursion due to numerical instability when computing the number of clusters ([PR](https://github.com/georust/rstar/pull/166))
+- Allow 1D `RTree`s to be created ([PR](https://github.com/georust/rstar/pull/169))
 
 # 0.12.0
 

--- a/rstar/src/params.rs
+++ b/rstar/src/params.rs
@@ -1,5 +1,5 @@
 use crate::algorithm::rstar::RStarInsertionStrategy;
-use crate::{Envelope, Point, RTree, RTreeObject};
+use crate::{RTree, RTreeObject};
 
 /// Defines static parameters for an r-tree.
 ///
@@ -106,11 +106,5 @@ pub fn verify_parameters<T: RTreeObject, P: RTreeParams>() {
         P::REINSERTION_COUNT < max_reinsertion_count,
         "REINSERTION_COUNT too large. Must be smaller than {:?}",
         max_reinsertion_count
-    );
-
-    let dimension = <T::Envelope as Envelope>::Point::DIMENSIONS;
-    assert!(
-        dimension > 1,
-        "Point dimension too small - must be at least 2"
     );
 }

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -409,7 +409,7 @@ mod tests {
 
     macro_rules! test_tuple_configuration {
         ($($index:expr),*) => {
-            let a = ($($index),*);
+            let a = ($($index),*,);
             $(assert_eq!(a.nth($index), $index));*
         }
     }
@@ -425,6 +425,7 @@ mod tests {
         assert_eq!(long_int.nth(8), 8);
 
         // Generate the code to test every nth function for every Tuple length
+        test_tuple_configuration!(0);
         test_tuple_configuration!(0, 1);
         test_tuple_configuration!(0, 1, 2);
         test_tuple_configuration!(0, 1, 2, 3);


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This PR removes the parameter validation to allow 1D `RTree`s to be created.

1D `RTree`s already seem to work fine as far as I can tell from a simple example I just tested. I've looked through the places where we reference "dimensions" but most of them just loop from `0..dimensions`. We even explicitly support single dimensions in 1D tuples and some other places.

Motivation described in #111