### PR TITLE
Fix AABB::from_points which relied on implementation details of AABB::new_empty

### DIFF
--- a/rstar/src/envelope.rs
+++ b/rstar/src/envelope.rs
@@ -37,8 +37,8 @@ pub trait Envelope: Clone + PartialEq + ::core::fmt::Debug {
     ///
     /// # Notes
     /// - While euclidean distance will be the correct choice for most use cases, any distance metric
-    /// fulfilling the [usual axioms](https://en.wikipedia.org/wiki/Metric_space)
-    /// can be used when implementing this method
+    ///   fulfilling the [usual axioms](https://en.wikipedia.org/wiki/Metric_space)
+    ///   can be used when implementing this method
     /// - Implementers **must** ensure that the distance metric used matches that of [crate::PointDistance::distance_2]
     fn distance_2(&self, point: &Self::Point) -> <Self::Point as Point>::Scalar;
 

--- a/rstar/src/object.rs
+++ b/rstar/src/object.rs
@@ -149,8 +149,8 @@ pub trait PointDistance: RTreeObject {
     ///
     /// # Notes
     /// - While euclidean distance will be the correct choice for most use cases, any distance metric
-    /// fulfilling the [usual axioms](https://en.wikipedia.org/wiki/Metric_space)
-    /// can be used when implementing this method
+    ///   fulfilling the [usual axioms](https://en.wikipedia.org/wiki/Metric_space)
+    ///   can be used when implementing this method
     /// - Implementers **must** ensure that the distance metric used matches that of [crate::Envelope::distance_2]
     fn distance_2(
         &self,

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -115,7 +115,7 @@ where
 /// # Type Parameters
 /// * `T`: The type of objects stored in the r-tree.
 /// * `Params`: Compile time parameters that change the r-tree's internal layout. Refer to the
-/// [RTreeParams] trait for more information.
+///   [RTreeParams] trait for more information.
 ///
 /// # Defining methods generic over r-trees
 /// If a library defines a method that should be generic over the r-tree type signature, make


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This method does not just need an empty AABB, but actually requires that the lower/upper corners use max/min values of the point coordinates.

This change therefore open-codes this to keep these invariants and the code that relies on them close together.

A changelog entry should not be necessary as we luckily did not yet release the regression.

Closes #170 