### PR TITLE
Better handling of empty rects

### DIFF
--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -252,4 +252,25 @@ mod test {
         let aabb = AABB::from_points(&[(3., 3., 3.), (4., 4., 4.)]);
         assert_eq!(aabb, AABB::from_corners((3., 3., 3.), (4., 4., 4.)));
     }
+
+    #[test]
+    fn empty_rect() {
+        let empty = AABB::<[f32; 2]>::new_empty();
+
+        let other = AABB::from_corners([1.0, 1.0], [1.0, 1.0]);
+        let subject = empty.merged(&other);
+        assert_eq!(other, subject);
+
+        let other = AABB::from_corners([0.0, 0.0], [0.0, 0.0]);
+        let subject = empty.merged(&other);
+        assert_eq!(other, subject);
+
+        let other = AABB::from_corners([0.5, 0.5], [0.5, 0.5]);
+        let subject = empty.merged(&other);
+        assert_eq!(other, subject);
+
+        let other = AABB::from_corners([-0.5, -0.5], [-0.5, -0.5]);
+        let subject = empty.merged(&other);
+        assert_eq!(other, subject);
+    }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ not yet] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

As an alternative to https://github.com/georust/rstar/pull/181, which fixes the same bug, but maintains the spirit of #162 by avoiding comparison with huge/tiny floats.

This is a draft because there are several things I'm not sure how to handle, and I'm out of time for today! But if someone is interested in building off of it, feel free!