### PR TITLE
Re-export nearest neighbor iterators so they are nameable in downstream crates.

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Added
+- Added missing re-exports of nearest neighbor iterators so they can be named in downstream crates. ([PR](https://github.com/georust/rstar/pull/186))
+
 # 0.12.2
 
 ## Changed

--- a/rstar/src/algorithm/iterators.rs
+++ b/rstar/src/algorithm/iterators.rs
@@ -9,6 +9,7 @@ use crate::RTree;
 use smallvec::SmallVec;
 
 pub use super::intersection_iterator::IntersectionIterator;
+pub use super::nearest_neighbor::{NearestNeighborDistance2Iterator, NearestNeighborIterator};
 pub use super::removal::{DrainIterator, IntoIter};
 
 /// Iterator returned by [`RTree::locate_all_at_point`].

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -2,6 +2,9 @@ use crate::node::{ParentNode, RTreeNode};
 use crate::point::{min_inline, Point};
 use crate::{Envelope, PointDistance, RTreeObject};
 
+#[cfg(doc)]
+use crate::RTree;
+
 use alloc::collections::BinaryHeap;
 #[cfg(not(test))]
 use alloc::{vec, vec::Vec};
@@ -51,7 +54,10 @@ impl<'a, T> NearestNeighborDistance2Iterator<'a, T>
 where
     T: PointDistance,
 {
-    pub fn new(root: &'a ParentNode<T>, query_point: <T::Envelope as Envelope>::Point) -> Self {
+    pub(crate) fn new(
+        root: &'a ParentNode<T>,
+        query_point: <T::Envelope as Envelope>::Point,
+    ) -> Self {
         let mut result = NearestNeighborDistance2Iterator {
             nodes: SmallHeap::new(),
             query_point,
@@ -106,6 +112,7 @@ where
     }
 }
 
+/// Iterator returned by [`RTree::nearest_neighbor_iter_with_distance_2`].
 pub struct NearestNeighborDistance2Iterator<'a, T>
 where
     T: PointDistance + 'a,
@@ -118,7 +125,10 @@ impl<'a, T> NearestNeighborIterator<'a, T>
 where
     T: PointDistance,
 {
-    pub fn new(root: &'a ParentNode<T>, query_point: <T::Envelope as Envelope>::Point) -> Self {
+    pub(crate) fn new(
+        root: &'a ParentNode<T>,
+        query_point: <T::Envelope as Envelope>::Point,
+    ) -> Self {
         NearestNeighborIterator {
             iter: NearestNeighborDistance2Iterator::new(root, query_point),
         }
@@ -136,6 +146,7 @@ where
     }
 }
 
+/// Iterator returned by [`RTree::nearest_neighbor_iter`].
 pub struct NearestNeighborIterator<'a, T>
 where
     T: PointDistance + 'a,


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.

Closes #185 