### PR TITLE
Make RTree methods take owned values where it makes sense

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Added
 - Added missing re-exports of nearest neighbor iterators so they can be named in downstream crates. ([PR](https://github.com/georust/rstar/pull/186))
 
+## Changed
+- Made `RStar` methods take `Point` and `Envelope` as owned values where it makes sense ([PR](https://github.com/georust/rstar/pull/189))
+
 # 0.12.2
 
 ## Changed

--- a/rstar/src/algorithm/iterators.rs
+++ b/rstar/src/algorithm/iterators.rs
@@ -287,10 +287,10 @@ mod test {
 
         let query_points = create_random_points(20, SEED_1);
 
-        for p in &query_points {
+        for p in query_points {
             let contained_sequential: Vec<_> = rectangles
                 .iter()
-                .filter(|rectangle| rectangle.envelope().contains_point(p))
+                .filter(|rectangle| rectangle.envelope().contains_point(&p))
                 .cloned()
                 .collect();
 
@@ -317,7 +317,7 @@ mod test {
             .collect();
         let len = contained_in_envelope.len();
         assert!(10 < len && len < 90, "unexpected point distribution");
-        let located: Vec<_> = tree.locate_in_envelope(&envelope).cloned().collect();
+        let located: Vec<_> = tree.locate_in_envelope(envelope).cloned().collect();
         assert_eq!(len, located.len());
         for point in &contained_in_envelope {
             assert!(located.contains(point));

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -71,7 +71,7 @@ where
             ref mut nodes,
             ref query_point,
         } = self;
-        nodes.extend(children.iter().map(|child| {
+        nodes.extend(children.iter().map(|child: &RTreeNode<T>| {
             let distance = match child {
                 RTreeNode::Parent(ref data) => data.envelope.distance_2(query_point),
                 RTreeNode::Leaf(ref t) => t.distance_2(query_point),
@@ -331,7 +331,7 @@ mod test {
     #[test]
     fn test_nearest_neighbor_empty() {
         let tree: RTree<[f32; 2]> = RTree::new();
-        assert!(tree.nearest_neighbor(&[0.0, 213.0]).is_none());
+        assert!(tree.nearest_neighbor([0.0, 213.0]).is_none());
     }
 
     #[test]
@@ -340,7 +340,7 @@ mod test {
         let tree = RTree::bulk_load(points.clone());
 
         let sample_points = create_random_points(100, SEED_2);
-        for sample_point in &sample_points {
+        for sample_point in sample_points {
             let mut nearest = None;
             let mut closest_dist = f64::INFINITY;
             for point in &points {
@@ -387,10 +387,10 @@ mod test {
         let tree = RTree::bulk_load(points.clone());
 
         let sample_points = create_random_points(50, SEED_2);
-        for sample_point in &sample_points {
+        for sample_point in sample_points {
             points.sort_by(|r, l| {
-                r.distance_2(sample_point)
-                    .partial_cmp(&l.distance_2(sample_point))
+                r.distance_2(&sample_point)
+                    .partial_cmp(&l.distance_2(&sample_point))
                     .unwrap()
             });
             let collected: Vec<_> = tree.nearest_neighbor_iter(sample_point).cloned().collect();
@@ -404,10 +404,10 @@ mod test {
         let tree = RTree::bulk_load(points);
 
         let sample_points = create_random_points(50, SEED_1);
-        for sample_point in &sample_points {
+        for sample_point in sample_points {
             let mut last_distance = 0.0;
             for (point, distance) in tree.nearest_neighbor_iter_with_distance_2(sample_point) {
-                assert_eq!(point.distance_2(sample_point), distance);
+                assert_eq!(point.distance_2(&sample_point), distance);
                 assert!(last_distance < distance);
                 last_distance = distance;
             }

--- a/rstar/src/algorithm/removal.rs
+++ b/rstar/src/algorithm/removal.rs
@@ -264,14 +264,14 @@ mod test {
         let later_insertions = create_random_points(SIZE, SEED_2);
         let mut tree = RTree::bulk_load(points.clone());
         for (point_to_remove, point_to_add) in points.iter().zip(later_insertions.iter()) {
-            assert!(tree.remove_at_point(point_to_remove).is_some());
+            assert!(tree.remove_at_point(*point_to_remove).is_some());
             tree.insert(*point_to_add);
         }
         assert_eq!(tree.size(), SIZE);
         assert!(points.iter().all(|p| !tree.contains(p)));
         assert!(later_insertions.iter().all(|p| tree.contains(p)));
         for point in &later_insertions {
-            assert!(tree.remove_at_point(point).is_some());
+            assert!(tree.remove_at_point(*point).is_some());
         }
         assert_eq!(tree.size(), 0);
     }
@@ -308,10 +308,10 @@ mod test {
     fn test_remove_at_point() {
         let points = create_random_points(1000, SEED_1);
         let mut tree = RTree::bulk_load(points.clone());
-        for point in &points {
+        for point in points {
             let size_before_removal = tree.size();
             assert!(tree.remove_at_point(point).is_some());
-            assert!(tree.remove_at_point(&[1000.0, 1000.0]).is_none());
+            assert!(tree.remove_at_point([1000.0, 1000.0]).is_none());
             assert_eq!(size_before_removal - 1, tree.size());
         }
     }

--- a/rstar/src/mint.rs
+++ b/rstar/src/mint.rs
@@ -27,7 +27,7 @@
 //!
 //! rtree.insert(mint_point2);
 //!
-//! assert_eq!(rtree.nearest_neighbor(&mint_point1), Some(&mint_point2));
+//! assert_eq!(rtree.nearest_neighbor(mint_point1), Some(&mint_point2));
 //! ```
 
 use crate::{Point, RTreeNum};

--- a/rstar/src/object.rs
+++ b/rstar/src/object.rs
@@ -63,15 +63,15 @@ use crate::point::{Point, PointExt};
 ///
 /// // Now we are ready to ask some questions!
 /// let envelope = AABB::from_point([0.5, 0.5]);
-/// let likely_sarah_croft = tree.locate_in_envelope(&envelope).next();
+/// let likely_sarah_croft = tree.locate_in_envelope(envelope).next();
 /// println!("Found {:?} lurking around at (0.5, 0.5)!", likely_sarah_croft.unwrap().name);
 /// # assert!(likely_sarah_croft.is_some());
 ///
 /// let unit_square = AABB::from_corners([-1.0, -1.0], [1., 1.]);
-/// for player in tree.locate_in_envelope(&unit_square) {
+/// for player in tree.locate_in_envelope(unit_square) {
 ///    println!("And here is {:?} spelunking in the unit square.", player.name);
 /// }
-/// # assert_eq!(tree.locate_in_envelope(&unit_square).count(), 2);
+/// # assert_eq!(tree.locate_in_envelope(unit_square).count(), 2);
 /// ```
 pub trait RTreeObject {
     /// The object's envelope type. Usually, [AABB] will be the right choice.

--- a/rstar/src/primitives/cached_envelope.rs
+++ b/rstar/src/primitives/cached_envelope.rs
@@ -120,7 +120,7 @@ mod test {
         ));
         let my_location = [0.0, 0.0];
         // Now find the closest line
-        let place = lines.nearest_neighbor(&my_location).unwrap();
+        let place = lines.nearest_neighbor(my_location).unwrap();
 
         assert_eq!(place.data, "Line A");
     }

--- a/rstar/src/primitives/geom_with_data.rs
+++ b/rstar/src/primitives/geom_with_data.rs
@@ -25,7 +25,7 @@ use crate::{object::RTreeObject, point::Point};
 /// let my_location = [0.0, 0.0];
 ///
 /// // Now find the closest restaurant!
-/// let place = restaurants.nearest_neighbor(&my_location).unwrap();
+/// let place = restaurants.nearest_neighbor(my_location).unwrap();
 /// println!("Let's go to {}", place.data);
 /// println!("It's really close, only {} miles", place.distance_2(&my_location));
 /// ```
@@ -129,7 +129,7 @@ mod test {
         ));
         let my_location = [0.0, 0.0];
         // Now find the closest line
-        let place = lines.nearest_neighbor(&my_location).unwrap();
+        let place = lines.nearest_neighbor(my_location).unwrap();
 
         assert_eq!(place.data, "Line A");
     }

--- a/rstar/src/primitives/point_with_data.rs
+++ b/rstar/src/primitives/point_with_data.rs
@@ -22,7 +22,7 @@ use crate::{Point, PointDistance, RTreeObject, AABB};
 /// let my_location = [0.0, 0.0];
 ///
 /// // Now find the closest restaurant!
-/// let place = restaurants.nearest_neighbor(&my_location).unwrap();
+/// let place = restaurants.nearest_neighbor(my_location).unwrap();
 /// println!("Let's go to {}", place.data);
 /// println!("It's really close, only {} miles", place.distance_2(&my_location))
 /// ```

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -71,9 +71,9 @@ where
 /// tree.insert([0.2, 0.1]);
 /// tree.insert([0.3, 0.0]);
 ///
-/// assert_eq!(tree.nearest_neighbor(&[0.4, -0.1]), Some(&[0.3, 0.0]));
+/// assert_eq!(tree.nearest_neighbor([0.4, -0.1]), Some(&[0.3, 0.0]));
 /// tree.remove(&[0.3, 0.0]);
-/// assert_eq!(tree.nearest_neighbor(&[0.4, 0.3]), Some(&[0.2, 0.1]));
+/// assert_eq!(tree.nearest_neighbor([0.4, 0.3]), Some(&[0.2, 0.1]));
 ///
 /// assert_eq!(tree.size(), 2);
 /// // &RTree implements IntoIterator!
@@ -327,27 +327,24 @@ where
     /// ]);
     /// let half_unit_square = AABB::from_corners([0.0, 0.0], [0.5, 1.0]);
     /// let unit_square = AABB::from_corners([0.0, 0.0], [1.0, 1.0]);
-    /// let elements_in_half_unit_square = tree.locate_in_envelope(&half_unit_square);
-    /// let elements_in_unit_square = tree.locate_in_envelope(&unit_square);
+    /// let elements_in_half_unit_square = tree.locate_in_envelope(half_unit_square);
+    /// let elements_in_unit_square = tree.locate_in_envelope(unit_square);
     /// assert_eq!(elements_in_half_unit_square.count(), 2);
     /// assert_eq!(elements_in_unit_square.count(), 3);
     /// ```
-    pub fn locate_in_envelope(&self, envelope: &T::Envelope) -> LocateInEnvelope<T> {
-        LocateInEnvelope::new(&self.root, SelectInEnvelopeFunction::new(envelope.clone()))
+    pub fn locate_in_envelope(&self, envelope: T::Envelope) -> LocateInEnvelope<T> {
+        LocateInEnvelope::new(&self.root, SelectInEnvelopeFunction::new(envelope))
     }
 
     /// Mutable variant of [locate_in_envelope](#method.locate_in_envelope).
-    pub fn locate_in_envelope_mut(&mut self, envelope: &T::Envelope) -> LocateInEnvelopeMut<T> {
-        LocateInEnvelopeMut::new(
-            &mut self.root,
-            SelectInEnvelopeFunction::new(envelope.clone()),
-        )
+    pub fn locate_in_envelope_mut(&mut self, envelope: T::Envelope) -> LocateInEnvelopeMut<T> {
+        LocateInEnvelopeMut::new(&mut self.root, SelectInEnvelopeFunction::new(envelope))
     }
 
     /// Variant of [`locate_in_envelope`][Self::locate_in_envelope] using internal iteration.
     pub fn locate_in_envelope_int<'a, V, B>(
         &'a self,
-        envelope: &T::Envelope,
+        envelope: T::Envelope,
         mut visitor: V,
     ) -> ControlFlow<B>
     where
@@ -355,7 +352,7 @@ where
     {
         select_nodes(
             self.root(),
-            &SelectInEnvelopeFunction::new(envelope.clone()),
+            &SelectInEnvelopeFunction::new(envelope),
             &mut visitor,
         )
     }
@@ -363,7 +360,7 @@ where
     /// Mutable variant of [`locate_in_envelope_mut`][Self::locate_in_envelope_mut].
     pub fn locate_in_envelope_int_mut<'a, V, B>(
         &'a mut self,
-        envelope: &T::Envelope,
+        envelope: T::Envelope,
         mut visitor: V,
     ) -> ControlFlow<B>
     where
@@ -371,7 +368,7 @@ where
     {
         select_nodes_mut(
             self.root_mut(),
-            &SelectInEnvelopeFunction::new(envelope.clone()),
+            &SelectInEnvelopeFunction::new(envelope),
             &mut visitor,
         )
     }
@@ -419,43 +416,43 @@ where
     ///   middle_piece.into(),
     /// ]);
     ///
-    /// let elements_intersecting_left_piece = tree.locate_in_envelope_intersecting(&left_piece);
+    /// let elements_intersecting_left_piece = tree.locate_in_envelope_intersecting(left_piece);
     /// // The left piece should not intersect the right piece!
     /// assert_eq!(elements_intersecting_left_piece.count(), 2);
-    /// let elements_intersecting_middle = tree.locate_in_envelope_intersecting(&middle_piece);
+    /// let elements_intersecting_middle = tree.locate_in_envelope_intersecting(middle_piece);
     /// // Only the middle piece intersects all pieces within the tree
     /// assert_eq!(elements_intersecting_middle.count(), 3);
     ///
     /// let large_piece = AABB::from_corners([-100., -100.], [100., 100.]);
-    /// let elements_intersecting_large_piece = tree.locate_in_envelope_intersecting(&large_piece);
+    /// let elements_intersecting_large_piece = tree.locate_in_envelope_intersecting(large_piece);
     /// // Any element that is fully contained should also be returned:
     /// assert_eq!(elements_intersecting_large_piece.count(), 3);
     /// ```
     pub fn locate_in_envelope_intersecting(
         &self,
-        envelope: &T::Envelope,
+        envelope: T::Envelope,
     ) -> LocateInEnvelopeIntersecting<T> {
         LocateInEnvelopeIntersecting::new(
             &self.root,
-            SelectInEnvelopeFuncIntersecting::new(envelope.clone()),
+            SelectInEnvelopeFuncIntersecting::new(envelope),
         )
     }
 
     /// Mutable variant of [locate_in_envelope_intersecting](#method.locate_in_envelope_intersecting)
     pub fn locate_in_envelope_intersecting_mut(
         &mut self,
-        envelope: &T::Envelope,
+        envelope: T::Envelope,
     ) -> LocateInEnvelopeIntersectingMut<T> {
         LocateInEnvelopeIntersectingMut::new(
             &mut self.root,
-            SelectInEnvelopeFuncIntersecting::new(envelope.clone()),
+            SelectInEnvelopeFuncIntersecting::new(envelope),
         )
     }
 
     /// Variant of [`locate_in_envelope_intersecting`][Self::locate_in_envelope_intersecting] using internal iteration.
     pub fn locate_in_envelope_intersecting_int<'a, V, B>(
         &'a self,
-        envelope: &T::Envelope,
+        envelope: T::Envelope,
         mut visitor: V,
     ) -> ControlFlow<B>
     where
@@ -463,7 +460,7 @@ where
     {
         select_nodes(
             self.root(),
-            &SelectInEnvelopeFuncIntersecting::new(envelope.clone()),
+            &SelectInEnvelopeFuncIntersecting::new(envelope),
             &mut visitor,
         )
     }
@@ -471,7 +468,7 @@ where
     /// Mutable variant of [`locate_in_envelope_intersecting_int`][Self::locate_in_envelope_intersecting_int].
     pub fn locate_in_envelope_intersecting_int_mut<'a, V, B>(
         &'a mut self,
-        envelope: &T::Envelope,
+        envelope: T::Envelope,
         mut visitor: V,
     ) -> ControlFlow<B>
     where
@@ -479,7 +476,7 @@ where
     {
         select_nodes_mut(
             self.root_mut(),
-            &SelectInEnvelopeFuncIntersecting::new(envelope.clone()),
+            &SelectInEnvelopeFuncIntersecting::new(envelope),
             &mut visitor,
         )
     }
@@ -605,20 +602,20 @@ where
     /// is used to determine if a tree element contains the given point.
     ///
     /// If multiple elements contain the given point, any of them is returned.
-    pub fn locate_at_point(&self, point: &<T::Envelope as Envelope>::Point) -> Option<&T> {
+    pub fn locate_at_point(&self, point: <T::Envelope as Envelope>::Point) -> Option<&T> {
         self.locate_all_at_point(point).next()
     }
 
     /// Mutable variant of [RTree::locate_at_point].
     pub fn locate_at_point_mut(
         &mut self,
-        point: &<T::Envelope as Envelope>::Point,
+        point: <T::Envelope as Envelope>::Point,
     ) -> Option<&mut T> {
         self.locate_all_at_point_mut(point).next()
     }
 
     /// Variant of [`locate_at_point`][Self::locate_at_point] using internal iteration.
-    pub fn locate_at_point_int(&self, point: &<T::Envelope as Envelope>::Point) -> Option<&T> {
+    pub fn locate_at_point_int(&self, point: <T::Envelope as Envelope>::Point) -> Option<&T> {
         match self.locate_all_at_point_int(point, ControlFlow::Break) {
             ControlFlow::Break(node) => Some(node),
             ControlFlow::Continue(()) => None,
@@ -628,7 +625,7 @@ where
     /// Mutable variant of [`locate_at_point_int`][Self::locate_at_point_int].
     pub fn locate_at_point_int_mut(
         &mut self,
-        point: &<T::Envelope as Envelope>::Point,
+        point: <T::Envelope as Envelope>::Point,
     ) -> Option<&mut T> {
         match self.locate_all_at_point_int_mut(point, ControlFlow::Break) {
             ControlFlow::Break(node) => Some(node),
@@ -650,45 +647,41 @@ where
     ///   Rectangle::from_corners([1.0, 1.0], [3.0, 3.0])
     /// ]);
     ///
-    /// assert_eq!(tree.locate_all_at_point(&[1.5, 1.5]).count(), 2);
-    /// assert_eq!(tree.locate_all_at_point(&[0.0, 0.0]).count(), 1);
-    /// assert_eq!(tree.locate_all_at_point(&[-1., 0.0]).count(), 0);
+    /// assert_eq!(tree.locate_all_at_point([1.5, 1.5]).count(), 2);
+    /// assert_eq!(tree.locate_all_at_point([0.0, 0.0]).count(), 1);
+    /// assert_eq!(tree.locate_all_at_point([-1., 0.0]).count(), 0);
     /// ```
     pub fn locate_all_at_point(
         &self,
-        point: &<T::Envelope as Envelope>::Point,
+        point: <T::Envelope as Envelope>::Point,
     ) -> LocateAllAtPoint<T> {
-        LocateAllAtPoint::new(&self.root, SelectAtPointFunction::new(point.clone()))
+        LocateAllAtPoint::new(&self.root, SelectAtPointFunction::new(point))
     }
 
     /// Mutable variant of [`locate_all_at_point`][Self::locate_all_at_point].
     pub fn locate_all_at_point_mut(
         &mut self,
-        point: &<T::Envelope as Envelope>::Point,
+        point: <T::Envelope as Envelope>::Point,
     ) -> LocateAllAtPointMut<T> {
-        LocateAllAtPointMut::new(&mut self.root, SelectAtPointFunction::new(point.clone()))
+        LocateAllAtPointMut::new(&mut self.root, SelectAtPointFunction::new(point))
     }
 
     /// Variant of [`locate_all_at_point`][Self::locate_all_at_point] using internal iteration.
     pub fn locate_all_at_point_int<'a, V, B>(
         &'a self,
-        point: &<T::Envelope as Envelope>::Point,
+        point: <T::Envelope as Envelope>::Point,
         mut visitor: V,
     ) -> ControlFlow<B>
     where
         V: FnMut(&'a T) -> ControlFlow<B>,
     {
-        select_nodes(
-            &self.root,
-            &SelectAtPointFunction::new(point.clone()),
-            &mut visitor,
-        )
+        select_nodes(&self.root, &SelectAtPointFunction::new(point), &mut visitor)
     }
 
     /// Mutable variant of [`locate_all_at_point_int`][Self::locate_all_at_point_int].
     pub fn locate_all_at_point_int_mut<'a, V, B>(
         &'a mut self,
-        point: &<T::Envelope as Envelope>::Point,
+        point: <T::Envelope as Envelope>::Point,
         mut visitor: V,
     ) -> ControlFlow<B>
     where
@@ -696,7 +689,7 @@ where
     {
         select_nodes_mut(
             &mut self.root,
-            &SelectAtPointFunction::new(point.clone()),
+            &SelectAtPointFunction::new(point),
             &mut visitor,
         )
     }
@@ -716,12 +709,12 @@ where
     ///   Rectangle::from_corners([1.0, 1.0], [3.0, 3.0])
     /// ]);
     ///
-    /// assert!(tree.remove_at_point(&[1.5, 1.5]).is_some());
-    /// assert!(tree.remove_at_point(&[1.5, 1.5]).is_some());
-    /// assert!(tree.remove_at_point(&[1.5, 1.5]).is_none());
+    /// assert!(tree.remove_at_point([1.5, 1.5]).is_some());
+    /// assert!(tree.remove_at_point([1.5, 1.5]).is_some());
+    /// assert!(tree.remove_at_point([1.5, 1.5]).is_none());
     ///```
-    pub fn remove_at_point(&mut self, point: &<T::Envelope as Envelope>::Point) -> Option<T> {
-        let removal_function = SelectAtPointFunction::new(point.clone());
+    pub fn remove_at_point(&mut self, point: <T::Envelope as Envelope>::Point) -> Option<T> {
+        let removal_function = SelectAtPointFunction::new(point);
         self.remove_with_selection_function(removal_function)
     }
 }
@@ -747,7 +740,7 @@ where
     /// assert!(tree.contains(&[0.0, 2.0]));
     /// ```
     pub fn contains(&self, t: &T) -> bool {
-        self.locate_in_envelope(&t.envelope()).any(|e| e == t)
+        self.locate_in_envelope(t.envelope()).any(|e| e == t)
     }
 
     /// Removes and returns an element of the r-tree equal (`==`) to a given element.
@@ -793,10 +786,10 @@ where
     ///   [0.0, 0.0],
     ///   [0.0, 1.0],
     /// ]);
-    /// assert_eq!(tree.nearest_neighbor(&[-1., 0.0]), Some(&[0.0, 0.0]));
-    /// assert_eq!(tree.nearest_neighbor(&[0.0, 2.0]), Some(&[0.0, 1.0]));
+    /// assert_eq!(tree.nearest_neighbor([-1., 0.0]), Some(&[0.0, 0.0]));
+    /// assert_eq!(tree.nearest_neighbor([0.0, 2.0]), Some(&[0.0, 1.0]));
     /// ```
-    pub fn nearest_neighbor(&self, query_point: &<T::Envelope as Envelope>::Point) -> Option<&T> {
+    pub fn nearest_neighbor(&self, query_point: <T::Envelope as Envelope>::Point) -> Option<&T> {
         if self.size > 0 {
             // The single-nearest-neighbor retrieval may in rare cases return None due to
             // rounding issues. The iterator will still work, though.
@@ -883,14 +876,14 @@ where
     ///   [0.0, 1.0],
     /// ]);
     ///
-    /// let nearest_neighbors = tree.nearest_neighbor_iter(&[0.5, 0.0]).collect::<Vec<_>>();
+    /// let nearest_neighbors = tree.nearest_neighbor_iter([0.5, 0.0]).collect::<Vec<_>>();
     /// assert_eq!(nearest_neighbors, vec![&[0.0, 0.0], &[0.0, 1.0]]);
     /// ```
     pub fn nearest_neighbor_iter(
         &self,
-        query_point: &<T::Envelope as Envelope>::Point,
+        query_point: <T::Envelope as Envelope>::Point,
     ) -> NearestNeighborIterator<T> {
-        nearest_neighbor::NearestNeighborIterator::new(&self.root, query_point.clone())
+        nearest_neighbor::NearestNeighborIterator::new(&self.root, query_point)
     }
 
     /// Returns `(element, distance^2)` tuples of the tree sorted by their distance to a given point.
@@ -900,9 +893,9 @@ where
     #[deprecated(note = "Please use nearest_neighbor_iter_with_distance_2 instead")]
     pub fn nearest_neighbor_iter_with_distance(
         &self,
-        query_point: &<T::Envelope as Envelope>::Point,
+        query_point: <T::Envelope as Envelope>::Point,
     ) -> NearestNeighborDistance2Iterator<T> {
-        nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, query_point.clone())
+        nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, query_point)
     }
 
     /// Returns `(element, distance^2)` tuples of the tree sorted by their distance to a given point.
@@ -911,9 +904,9 @@ where
     /// [PointDistance::distance_2].
     pub fn nearest_neighbor_iter_with_distance_2(
         &self,
-        query_point: &<T::Envelope as Envelope>::Point,
+        query_point: <T::Envelope as Envelope>::Point,
     ) -> NearestNeighborDistance2Iterator<T> {
-        nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, query_point.clone())
+        nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, query_point)
     }
 
     /// Removes the nearest neighbor for a given point and returns it.
@@ -928,13 +921,13 @@ where
     ///   [0.0, 0.0],
     ///   [0.0, 1.0],
     /// ]);
-    /// assert_eq!(tree.pop_nearest_neighbor(&[0.0, 0.0]), Some([0.0, 0.0]));
-    /// assert_eq!(tree.pop_nearest_neighbor(&[0.0, 0.0]), Some([0.0, 1.0]));
-    /// assert_eq!(tree.pop_nearest_neighbor(&[0.0, 0.0]), None);
+    /// assert_eq!(tree.pop_nearest_neighbor([0.0, 0.0]), Some([0.0, 0.0]));
+    /// assert_eq!(tree.pop_nearest_neighbor([0.0, 0.0]), Some([0.0, 1.0]));
+    /// assert_eq!(tree.pop_nearest_neighbor([0.0, 0.0]), None);
     /// ```
     pub fn pop_nearest_neighbor(
         &mut self,
-        query_point: &<T::Envelope as Envelope>::Point,
+        query_point: <T::Envelope as Envelope>::Point,
     ) -> Option<T> {
         if let Some(neighbor) = self.nearest_neighbor(query_point) {
             let removal_function = SelectByAddressFunction::new(neighbor.envelope(), neighbor);


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [X] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Fixes #188.

This makes the API nicer, and I don't think I touched anything low-level enough for it to have performance implications.