### PR TITLE
Fix Clippy warning (surfaced in Rust 1.89) related to lifetime elision

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ## Changed
 - Made `RStar` methods take `Point` and `Envelope` as owned values where it makes sense ([PR](https://github.com/georust/rstar/pull/189))
+- Fix Clippy warning (surfaced in Rust 1.89) related to lifetime elision
 
 # 0.12.2
 

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -294,7 +294,7 @@ where
     ///     println!("This tree contains point {:?}", point);
     /// }
     /// ```
-    pub fn iter(&self) -> RTreeIterator<T> {
+    pub fn iter(&self) -> RTreeIterator<'_, T> {
         RTreeIterator::new(&self.root, SelectAllFunc)
     }
 
@@ -308,7 +308,7 @@ where
     /// If the position or location of an inserted object need to change, you will need to [RTree::remove]
     /// and reinsert it.
     ///
-    pub fn iter_mut(&mut self) -> RTreeIteratorMut<T> {
+    pub fn iter_mut(&mut self) -> RTreeIteratorMut<'_, T> {
         RTreeIteratorMut::new(&mut self.root, SelectAllFunc)
     }
 
@@ -332,12 +332,12 @@ where
     /// assert_eq!(elements_in_half_unit_square.count(), 2);
     /// assert_eq!(elements_in_unit_square.count(), 3);
     /// ```
-    pub fn locate_in_envelope(&self, envelope: T::Envelope) -> LocateInEnvelope<T> {
+    pub fn locate_in_envelope(&self, envelope: T::Envelope) -> LocateInEnvelope<'_, T> {
         LocateInEnvelope::new(&self.root, SelectInEnvelopeFunction::new(envelope))
     }
 
     /// Mutable variant of [locate_in_envelope](#method.locate_in_envelope).
-    pub fn locate_in_envelope_mut(&mut self, envelope: T::Envelope) -> LocateInEnvelopeMut<T> {
+    pub fn locate_in_envelope_mut(&mut self, envelope: T::Envelope) -> LocateInEnvelopeMut<'_, T> {
         LocateInEnvelopeMut::new(&mut self.root, SelectInEnvelopeFunction::new(envelope))
     }
 
@@ -380,7 +380,7 @@ where
     /// See
     /// [drain_with_selection_function](#method.drain_with_selection_function)
     /// for more information.
-    pub fn drain(&mut self) -> DrainIterator<T, SelectAllFunc, Params> {
+    pub fn drain(&mut self) -> DrainIterator<'_, T, SelectAllFunc, Params> {
         self.drain_with_selection_function(SelectAllFunc)
     }
 
@@ -388,7 +388,7 @@ where
     pub fn drain_in_envelope(
         &mut self,
         envelope: T::Envelope,
-    ) -> DrainIterator<T, SelectInEnvelopeFunction<T>, Params> {
+    ) -> DrainIterator<'_, T, SelectInEnvelopeFunction<T>, Params> {
         let sel = SelectInEnvelopeFunction::new(envelope);
         self.drain_with_selection_function(sel)
     }
@@ -431,7 +431,7 @@ where
     pub fn locate_in_envelope_intersecting(
         &self,
         envelope: T::Envelope,
-    ) -> LocateInEnvelopeIntersecting<T> {
+    ) -> LocateInEnvelopeIntersecting<'_, T> {
         LocateInEnvelopeIntersecting::new(
             &self.root,
             SelectInEnvelopeFuncIntersecting::new(envelope),
@@ -442,7 +442,7 @@ where
     pub fn locate_in_envelope_intersecting_mut(
         &mut self,
         envelope: T::Envelope,
-    ) -> LocateInEnvelopeIntersectingMut<T> {
+    ) -> LocateInEnvelopeIntersectingMut<'_, T> {
         LocateInEnvelopeIntersectingMut::new(
             &mut self.root,
             SelectInEnvelopeFuncIntersecting::new(envelope),
@@ -491,7 +491,7 @@ where
     pub fn locate_with_selection_function<S: SelectionFunction<T>>(
         &self,
         selection_function: S,
-    ) -> SelectionIterator<T, S> {
+    ) -> SelectionIterator<'_, T, S> {
         SelectionIterator::new(&self.root, selection_function)
     }
 
@@ -499,7 +499,7 @@ where
     pub fn locate_with_selection_function_mut<S: SelectionFunction<T>>(
         &mut self,
         selection_function: S,
-    ) -> SelectionIteratorMut<T, S> {
+    ) -> SelectionIteratorMut<'_, T, S> {
         SelectionIteratorMut::new(&mut self.root, selection_function)
     }
 
@@ -572,7 +572,10 @@ where
     /// iteration would stop the removal. However, the returned iterator
     /// must be properly dropped. Leaking this iterator leads to a leak
     /// amplification, where all the elements in the tree are leaked.
-    pub fn drain_with_selection_function<F>(&mut self, function: F) -> DrainIterator<T, F, Params>
+    pub fn drain_with_selection_function<F>(
+        &mut self,
+        function: F,
+    ) -> DrainIterator<'_, T, F, Params>
     where
         F: SelectionFunction<T>,
     {
@@ -585,7 +588,7 @@ where
     pub fn drain_in_envelope_intersecting(
         &mut self,
         envelope: T::Envelope,
-    ) -> DrainIterator<T, SelectInEnvelopeFuncIntersecting<T>, Params> {
+    ) -> DrainIterator<'_, T, SelectInEnvelopeFuncIntersecting<T>, Params> {
         let selection_function = SelectInEnvelopeFuncIntersecting::new(envelope);
         self.drain_with_selection_function(selection_function)
     }
@@ -654,7 +657,7 @@ where
     pub fn locate_all_at_point(
         &self,
         point: <T::Envelope as Envelope>::Point,
-    ) -> LocateAllAtPoint<T> {
+    ) -> LocateAllAtPoint<'_, T> {
         LocateAllAtPoint::new(&self.root, SelectAtPointFunction::new(point))
     }
 
@@ -662,7 +665,7 @@ where
     pub fn locate_all_at_point_mut(
         &mut self,
         point: <T::Envelope as Envelope>::Point,
-    ) -> LocateAllAtPointMut<T> {
+    ) -> LocateAllAtPointMut<'_, T> {
         LocateAllAtPointMut::new(&mut self.root, SelectAtPointFunction::new(point))
     }
 
@@ -906,7 +909,7 @@ where
         &self,
         query_point: <T::Envelope as Envelope>::Point,
         max_squared_radius: Distance<T>,
-    ) -> LocateWithinDistanceIterator<T> {
+    ) -> LocateWithinDistanceIterator<'_, T> {
         let selection_function = SelectWithinDistanceFunction::new(query_point, max_squared_radius);
         LocateWithinDistanceIterator::new(self.root(), selection_function)
     }
@@ -919,7 +922,7 @@ where
         &mut self,
         query_point: <T::Envelope as Envelope>::Point,
         max_squared_radius: Distance<T>,
-    ) -> DrainIterator<T, SelectWithinDistanceFunction<T>, Params> {
+    ) -> DrainIterator<'_, T, SelectWithinDistanceFunction<T>, Params> {
         let selection_function = SelectWithinDistanceFunction::new(query_point, max_squared_radius);
         self.drain_with_selection_function(selection_function)
     }
@@ -946,7 +949,7 @@ where
     pub fn nearest_neighbor_iter(
         &self,
         query_point: <T::Envelope as Envelope>::Point,
-    ) -> NearestNeighborIterator<T> {
+    ) -> NearestNeighborIterator<'_, T> {
         nearest_neighbor::NearestNeighborIterator::new(&self.root, query_point)
     }
 
@@ -958,7 +961,7 @@ where
     pub fn nearest_neighbor_iter_with_distance(
         &self,
         query_point: <T::Envelope as Envelope>::Point,
-    ) -> NearestNeighborDistance2Iterator<T> {
+    ) -> NearestNeighborDistance2Iterator<'_, T> {
         nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, query_point)
     }
 
@@ -969,7 +972,7 @@ where
     pub fn nearest_neighbor_iter_with_distance_2(
         &self,
         query_point: <T::Envelope as Envelope>::Point,
-    ) -> NearestNeighborDistance2Iterator<T> {
+    ) -> NearestNeighborDistance2Iterator<'_, T> {
         nearest_neighbor::NearestNeighborDistance2Iterator::new(&self.root, query_point)
     }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

