### PR TITLE
Fix Clippy warning for empty line after attribute

### DIFF
--- a/rstar/src/node.rs
+++ b/rstar/src/node.rs
@@ -17,7 +17,6 @@ use serde::{Deserialize, Serialize};
         deserialize = "T: Deserialize<'de>, T::Envelope: Deserialize<'de>"
     ))
 )]
-
 /// An internal tree node.
 ///
 /// For most applications, using this type should not be required.


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This surfaced after #202 and is blocking #201 (and #200)

