### PR TITLE
Remove geo benchmarks and fix benchmark API usage

### DIFF
--- a/rstar-benches/Cargo.toml
+++ b/rstar-benches/Cargo.toml
@@ -6,8 +6,6 @@ authors = ["Stefan Altmayer <stoeoef@gmail.com>", "The Georust Developers <mods@
 
 [dev-dependencies]
 criterion = { version = "0.5.0", features = ["html_reports"] }
-geo = "0.28.0"
-geo-types = { version = "0.7.9", features = ["use-rstar_0_12"] }
 rand = "0.8"
 rand_hc = "0.3"
 rstar = { path = "../rstar" }

--- a/rstar-benches/benches/benchmarks.rs
+++ b/rstar-benches/benches/benchmarks.rs
@@ -1,18 +1,12 @@
 #[macro_use]
 extern crate criterion;
-extern crate geo;
-extern crate geo_types;
 extern crate rand;
 extern crate rand_hc;
 extern crate rstar;
 
-use std::f64::consts::PI;
-
-use geo::{Coord, LineString, MapCoords, Polygon};
 use rand::{Rng, SeedableRng};
 use rand_hc::Hc128Rng;
 
-use rstar::primitives::CachedEnvelope;
 use rstar::{RStarInsertionStrategy, RTree, RTreeParams};
 
 use criterion::Criterion;
@@ -53,31 +47,6 @@ fn bulk_load_comparison(c: &mut Criterion) {
     });
 }
 
-fn bulk_load_complex_geom(c: &mut Criterion) {
-    c.bench_function("Bulk load complex geo-types geom", move |b| {
-        let polys: Vec<_> =
-            create_random_polygons(DEFAULT_BENCHMARK_TREE_SIZE, 4096, SEED_1).collect();
-
-        b.iter(|| {
-            RTree::<Polygon<f64>, Params>::bulk_load_with_params(polys.clone());
-        });
-    });
-}
-
-fn bulk_load_complex_geom_cached(c: &mut Criterion) {
-    c.bench_function(
-        "Bulk load complex geo-types geom with cached envelope",
-        move |b| {
-            let cached: Vec<_> = create_random_polygons(DEFAULT_BENCHMARK_TREE_SIZE, 4096, SEED_1)
-                .map(CachedEnvelope::new)
-                .collect();
-            b.iter(|| {
-                RTree::<CachedEnvelope<_>, Params>::bulk_load_with_params(cached.clone());
-            });
-        },
-    );
-}
-
 fn tree_creation_quality(c: &mut Criterion) {
     const SIZE: usize = 100_000;
     let points: Vec<_> = create_random_points(SIZE, SEED_1);
@@ -92,14 +61,14 @@ fn tree_creation_quality(c: &mut Criterion) {
     c.bench_function("bulk load quality", move |b| {
         b.iter(|| {
             for query_point in &query_points {
-                tree_bulk_loaded.nearest_neighbor(query_point).unwrap();
+                tree_bulk_loaded.nearest_neighbor(*query_point).unwrap();
             }
         })
     })
     .bench_function("sequential load quality", move |b| {
         b.iter(|| {
             for query_point in &query_points_cloned_1 {
-                tree_sequential.nearest_neighbor(query_point).unwrap();
+                tree_sequential.nearest_neighbor(*query_point).unwrap();
             }
         });
     });
@@ -110,7 +79,7 @@ fn locate_successful(c: &mut Criterion) {
     let query_point = points[500];
     let tree = RTree::<_, Params>::bulk_load_with_params(points);
     c.bench_function("locate_at_point (successful)", move |b| {
-        b.iter(|| tree.locate_at_point(&query_point).is_some())
+        b.iter(|| tree.locate_at_point(query_point).is_some())
     });
 }
 
@@ -119,7 +88,7 @@ fn locate_unsuccessful(c: &mut Criterion) {
     let tree = RTree::<_, Params>::bulk_load_with_params(points);
     let query_point = [0.7, 0.7];
     c.bench_function("locate_at_point (unsuccessful)", move |b| {
-        b.iter(|| tree.locate_at_point(&query_point).is_none())
+        b.iter(|| tree.locate_at_point(query_point).is_none())
     });
 }
 
@@ -128,7 +97,7 @@ fn locate_successful_internal(c: &mut Criterion) {
     let query_point = points[500];
     let tree = RTree::<_, Params>::bulk_load_with_params(points);
     c.bench_function("locate_at_point_int (successful)", move |b| {
-        b.iter(|| tree.locate_at_point_int(&query_point).is_some())
+        b.iter(|| tree.locate_at_point_int(query_point).is_some())
     });
 }
 
@@ -137,7 +106,7 @@ fn locate_unsuccessful_internal(c: &mut Criterion) {
     let tree = RTree::<_, Params>::bulk_load_with_params(points);
     let query_point = [0.7, 0.7];
     c.bench_function("locate_at_point_int (unsuccessful)", move |b| {
-        b.iter(|| tree.locate_at_point(&query_point).is_none())
+        b.iter(|| tree.locate_at_point(query_point).is_none())
     });
 }
 
@@ -145,8 +114,6 @@ criterion_group!(
     benches,
     bulk_load_baseline,
     bulk_load_comparison,
-    bulk_load_complex_geom,
-    bulk_load_complex_geom_cached,
     tree_creation_quality,
     locate_successful,
     locate_unsuccessful,
@@ -158,37 +125,4 @@ criterion_main!(benches);
 fn create_random_points(num_points: usize, seed: &[u8; 32]) -> Vec<[f64; 2]> {
     let mut rng = Hc128Rng::from_seed(*seed);
     (0..num_points).map(|_| rng.gen()).collect()
-}
-
-fn create_random_polygons(
-    num_points: usize,
-    size: usize,
-    seed: &[u8; 32],
-) -> impl Iterator<Item = Polygon<f64>> {
-    let mut rng = Hc128Rng::from_seed(*seed);
-    let base_polygon = circular_polygon(size);
-
-    (0..num_points).map(move |_| {
-        let [scale_x, scale_y]: [f64; 2] = rng.gen();
-        let [shift_x, shift_y]: [f64; 2] = rng.gen();
-        base_polygon.clone().map_coords(|c| Coord {
-            x: (shift_x + c.x) * scale_x,
-            y: (shift_y + c.y) * scale_y,
-        })
-    })
-}
-
-fn circular_polygon(steps: usize) -> Polygon<f64> {
-    let delta = 2. * PI / steps as f64;
-    let r = 1.0;
-
-    let ring = (0..steps)
-        .scan(0.0_f64, |angle, _step| {
-            let (sin, cos) = angle.sin_cos();
-            *angle += delta;
-            Some((r * cos, r * sin).into())
-        })
-        .collect();
-
-    Polygon::new(LineString(ring), Vec::new())
 }


### PR DESCRIPTION
Also fix up remaining benchmarks to conform to new API

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

As we can see in the [currently-failing tests in #204]((https://github.com/georust/rstar/actions/runs/17020252791/job/48248245424?pr=204)), running our tests using the patch directive in [`Cargo.toml`](https://github.com/georust/rstar/blob/dcafd58b86dfab3d89e8bae4685ee5dacb509eaa/Cargo.toml#L10-L11) causes a failure due to the `rstar-benches` package depending on `geo` due to the API change in #189 (if I've understood the issue correctly).

We could fix this by:

1. releasing a new version of rstar
2. updating geo to use that, publishing a new `geo` version
3. updating the Docker images to use the new `geo` version
4. updating #204 to use the new images.
 
Alternatively, we can remove the benchmarks that use `geo` and remove the `geo` dependency from `rstar-benches` (optionally moving them into `geo-types`).

