### PR TITLE
adapt to new rstar API, remove geo dependency

### DIFF
--- a/rstar-benches/Cargo.toml
+++ b/rstar-benches/Cargo.toml
@@ -6,7 +6,6 @@ authors = ["Stefan Altmayer <stoeoef@gmail.com>", "The Georust Developers <mods@
 
 [dev-dependencies]
 criterion = { version = "0.5.0", features = ["html_reports"] }
-geo = "0.28.0"
 geo-types = { version = "0.7.9", features = ["use-rstar_0_12"] }
 rand = "0.8"
 rand_hc = "0.3"


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [n/a] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Alternative to https://github.com/georust/rstar/pull/206

Rather than removing the bench as in #206, remove the `geo` dependency.

We were only using geo:MapCoords, and in this case I think "a little copying is better than a little dependency".