### PR TITLE
Avoid unclear diameter terminology in AABB::from_center.

### DIFF
--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -71,14 +71,14 @@ where
         Self { lower, upper }
     }
 
-    /// Creates a new AABB from a center and a diameter.
-    pub fn from_center(center: P, diameter: P::Scalar) -> Self {
-        let one = P::Scalar::one();
-        let two = one + one;
-        let radius = P::from_value(diameter / two);
+    /// Creates a new AABB from a center and a distance.
+    ///
+    /// Creates the smallest AABB which includes all points within `distance` of `center`.
+    pub fn from_center(center: P, distance: P::Scalar) -> Self {
+        let distance = P::from_value(distance);
 
-        let p1 = center.add(&radius);
-        let p2 = center.sub(&radius);
+        let p1 = center.add(&distance);
+        let p2 = center.sub(&distance);
 
         Self::from_corners(p1, p2)
     }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

