### PR TITLE
Rtrees in one dimension

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Implemented `RTreeObject` for `Arc<T>` and `Rc<T>`
 - Added `Envelope::is_empty`. ([PR](https://github.com/georust/rstar/pull/190))
 - New `AABB::from_center` utility constructor
+- Allow construction of 1D Rtrees.
 
 ## Fixed
 - Fix excessive memory retention in `bulk_load` from `Vec::split_off` over-capacity

--- a/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
+++ b/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
@@ -123,6 +123,7 @@ mod test {
     #[test]
     fn test_bulk_load_with_different_sizes() {
         for size in (0..100).map(|i| i * 7) {
+            test_bulk_load_with_size_and_dimension::<[i32; 1]>(size);
             test_bulk_load_with_size_and_dimension::<[i32; 2]>(size);
             test_bulk_load_with_size_and_dimension::<[i32; 3]>(size);
             test_bulk_load_with_size_and_dimension::<[i32; 4]>(size);

--- a/rstar/src/params.rs
+++ b/rstar/src/params.rs
@@ -107,7 +107,7 @@ pub fn verify_parameters<T: RTreeObject, P: RTreeParams>() {
 
     let dimension = <T::Envelope as Envelope>::Point::DIMENSIONS;
     assert!(
-        dimension > 1,
-        "Point dimension too small - must be at least 2"
+        dimension > 0,
+        "Point dimension too small - must be at least 1"
     );
 }

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -1215,6 +1215,8 @@ mod test {
     use crate::params::RTreeParams;
     use crate::test_utilities::{create_random_points, SEED_1};
     use crate::DefaultParams;
+    use crate::primitives::Rectangle;
+    use crate::aabb::AABB;
 
     struct TestParams;
     impl RTreeParams for TestParams {
@@ -1368,5 +1370,24 @@ mod test {
             tree.insert(node);
             tree.root().sanity_check::<DefaultParams>(false);
         }
+    }
+
+    #[test]
+    fn test_rtree_1d() {
+        let boxes: Vec<Rectangle<[f64; 1]>> = vec![
+            Rectangle::from_corners([0.0], [1.0]),
+            Rectangle::from_corners([0.0], [2.0]),
+            Rectangle::from_corners([1.0], [3.0]),
+            Rectangle::from_corners([2.0], [4.0]),
+            Rectangle::from_corners([3.0], [5.0]),
+            Rectangle::from_corners([4.0], [6.0]),
+            Rectangle::from_corners([5.0], [7.0]),
+        ];
+        let tree = RTree::bulk_load(boxes);
+        assert_eq!(tree.size(), 7);
+        assert_eq!(tree.locate_in_envelope_intersecting(AABB::from_corners([0.5], [1.5])).count(), 3);
+        assert_eq!(tree.locate_in_envelope_intersecting(AABB::from_corners([3.5], [4.5])).count(), 3);
+        assert_eq!(tree.locate_all_at_point([1.5]).count(), 2);
+        assert_eq!(tree.nearest_neighbor([1.5]), Some(&Rectangle::from_corners([0.0], [2.0])));
     }
 }


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Allow construction of 1D rtrees. I can't see at a glance why this shouldn't be okay. Added some basic tests.