### PR TITLE
create an AABB from known bounds

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Implemented `RTreeObject` for `Arc<T>` and `Rc<T>`
 - Added `Envelope::is_empty`. ([PR](https://github.com/georust/rstar/pull/190))
 - New `AABB::from_center` utility constructor
+- New `AABB::from_bounds` utility constructor
 
 ## Fixed
 - Fix excessive memory retention in `bulk_load` from `Vec::split_off` over-capacity

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -64,6 +64,13 @@ where
         }
     }
 
+    /// Returns the AABB from already known lower/upper bounds.
+    pub fn from_bounds(lower: P, upper: P) -> Self {
+        debug_assert!(lower.min_point(&upper) == lower);
+        debug_assert!(lower.max_point(&upper) == upper);
+        AABB { lower, upper }
+    }
+
     /// Creates a new AABB from a center and a diameter.
     pub fn from_center(center: P, diameter: P::Scalar) -> Self {
         let one = P::Scalar::one();
@@ -108,13 +115,6 @@ where
         } else {
             self.min_point(point).sub(point).length_2()
         }
-    }
-
-    /// Returns the AABB from already known lower/upper bounds.
-    pub fn from_bounds(lower: P, upper: P) -> Self {
-        debug_assert!(lower.min_point(&upper) == lower);
-        debug_assert!(lower.max_point(&upper) == upper);
-        AABB { lower, upper }
     }
 }
 

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -109,6 +109,13 @@ where
             self.min_point(point).sub(point).length_2()
         }
     }
+
+    /// Returns the AABB from already known lower/upper bounds.
+    pub fn from_bounds(lower: P, upper: P) -> Self {
+        debug_assert!(lower.min_point(&upper) == lower);
+        debug_assert!(lower.max_point(&upper) == upper);
+        AABB { lower, upper }
+    }
 }
 
 impl<P> Envelope for AABB<P>

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -58,7 +58,7 @@ where
 
     /// Creates a new AABB encompassing two points.
     pub fn from_corners(p1: P, p2: P) -> Self {
-        AABB {
+        Self {
             lower: p1.min_point(&p2),
             upper: p1.max_point(&p2),
         }
@@ -68,7 +68,7 @@ where
     pub fn from_bounds(lower: P, upper: P) -> Self {
         debug_assert!(lower.min_point(&upper) == lower);
         debug_assert!(lower.max_point(&upper) == upper);
-        AABB { lower, upper }
+        Self { lower, upper }
     }
 
     /// Creates a new AABB from a center and a diameter.

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -66,8 +66,8 @@ where
 
     /// Returns the AABB from already known lower/upper bounds.
     pub fn from_bounds(lower: P, upper: P) -> Self {
-        debug_assert!(lower.min_point(&upper) == lower);
-        debug_assert!(lower.max_point(&upper) == upper);
+        debug_assert_eq!(lower.min_point(&upper), lower);
+        debug_assert_eq!(lower.max_point(&upper), upper);
         Self { lower, upper }
     }
 


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

I tried using rstar, and had significantly worse results than I expected. In my benchmarks, I noticed the code was spending a lot of times finding min_point/max_point for the AABB construction even though I already knew them.

This PR adds a new utility constructor that takes known bounds, and asserts they are correct in debug mode