### PR TITLE
feat(rtree): Add support for `AsRef`/`AsMut` for `RTree<_, _>`

### DIFF
--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -219,6 +219,28 @@ where
     }
 }
 
+impl<T, Params> AsRef<RTree<T, Params>> for RTree<T, Params>
+where
+    T: RTreeObject,
+    Params: RTreeParams,
+{
+    #[inline]
+    fn as_ref(&self) -> &RTree<T, Params> {
+        self
+    }
+}
+
+impl<T, Params> AsMut<RTree<T, Params>> for RTree<T, Params>
+where
+    T: RTreeObject,
+    Params: RTreeParams,
+{
+    #[inline]
+    fn as_mut(&mut self) -> &mut RTree<T, Params> {
+        self
+    }
+}
+
 impl<T> RTree<T>
 where
     T: RTreeObject,


### PR DESCRIPTION
The purpose of this is to properly get rid of
https://docs.rs/rstared/0.13.1/rstared/struct.AsRefRTree.html, which only exists to introduce such an `AsRef<RTree<_, _>>` implementation.

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---
