### PR TITLE
Don't panic on non-finite bounds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v7
       - name: Install MSRV toolchain
-        uses: dtolnay/rust-toolchain@1.85.0
+        uses: dtolnay/rust-toolchain@1.90.0
       - name: Setup Rust cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2024,9 +2024,9 @@ dependencies = [
 
 [[package]]
 name = "ordered-float"
-version = "5.3.0"
+version = "5.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
+checksum = "8c7c9e0d9b23589f26070720bac724174bfec1083e82f7854cdd0267518343c0"
 dependencies = [
  "num-traits",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2581,6 +2581,7 @@ name = "rstar-benches"
 version = "0.1.1"
 dependencies = [
  "criterion",
+ "ordered-float",
  "rand 0.10.1",
  "rand_hc 0.5.0",
  "rstar 0.13.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2568,6 +2568,7 @@ dependencies = [
  "mint",
  "nalgebra",
  "num-traits",
+ "ordered-float",
  "rand 0.10.1",
  "rand_hc 0.5.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,9 @@ members = [
     "rstar-benches"
 ]
 
+[workspace.dependencies]
+ordered-float = { version = "5.5.0", default-features = false }
+
 # Ensure any transitive dependencies, e.g. via `geo`, use the local `rstar` crate
 [patch.crates-io]
 rstar = { path = "rstar" }

--- a/rstar-benches/Cargo.toml
+++ b/rstar-benches/Cargo.toml
@@ -9,6 +9,7 @@ rust-version = "1.68"
 criterion = { version = "0.8", features = ["html_reports"] }
 rand = "0.10"
 rand_hc = "0.5"
+ordered-float = { workspace = true, features = ["std"] }
 rstar = { path = "../rstar" }
 
 [[bench]]

--- a/rstar-benches/benches/benchmarks.rs
+++ b/rstar-benches/benches/benchmarks.rs
@@ -13,6 +13,7 @@ use rstar::primitives::CachedEnvelope;
 use rstar::{RStarInsertionStrategy, RTree, RTreeObject, RTreeParams, AABB};
 
 use criterion::Criterion;
+use ordered_float::NotNan;
 
 const SEED_1: &[u8; 32] = b"Gv0aHMtHkBGsUXNspGU9fLRuCWkZWHZx";
 const SEED_2: &[u8; 32] = b"km7DO4GeaFZfTcDXVpnO7ZJlgUY7hZiS";
@@ -47,6 +48,64 @@ fn bulk_load_comparison(c: &mut Criterion) {
                 rtree.insert(*point);
             }
         });
+    });
+}
+
+fn bulk_load_comparison_not_nan(c: &mut Criterion) {
+    c.bench_function("insert sequential (NotNan)", |b| {
+        let points: Vec<_> = create_random_points_not_nan(DEFAULT_BENCHMARK_TREE_SIZE, SEED_1);
+        b.iter(move || {
+            let mut rtree = rstar::RTree::new();
+            for point in &points {
+                rtree.insert(*point);
+            }
+        });
+    });
+}
+
+fn bulk_load_baseline_not_nan(c: &mut Criterion) {
+    c.bench_function("bulk load baseline (NotNan)", move |b| {
+        let points: Vec<_> = create_random_points_not_nan(DEFAULT_BENCHMARK_TREE_SIZE, SEED_1);
+
+        b.iter(|| {
+            RTree::<_, Params>::bulk_load_with_params(points.clone());
+        });
+    });
+}
+
+fn locate_successful_internal_not_nan(c: &mut Criterion) {
+    let points: Vec<_> = create_random_points_not_nan(100_000, SEED_1);
+    let query_point = points[500];
+    let tree = RTree::<_, Params>::bulk_load_with_params(points);
+    c.bench_function("locate_at_point_int (successful, NotNan)", move |b| {
+        b.iter(|| tree.locate_at_point_int(query_point).is_some())
+    });
+}
+
+fn locate_successful_not_nan(c: &mut Criterion) {
+    let points: Vec<_> = create_random_points_not_nan(100_000, SEED_1);
+    let query_point = points[500];
+    let tree = RTree::<_, Params>::bulk_load_with_params(points);
+    c.bench_function("locate_at_point (successful, NotNan)", move |b| {
+        b.iter(|| tree.locate_at_point(query_point).is_some())
+    });
+}
+
+fn locate_unsuccessful_not_nan(c: &mut Criterion) {
+    let points: Vec<_> = create_random_points_not_nan(100_000, SEED_1);
+    let tree = RTree::<_, Params>::bulk_load_with_params(points);
+    let query_point = not_nan([0.7, 0.7]);
+    c.bench_function("locate_at_point (unsuccessful, NotNan)", move |b| {
+        b.iter(|| tree.locate_at_point(query_point).is_none())
+    });
+}
+
+fn locate_unsuccessful_internal_not_nan(c: &mut Criterion) {
+    let points: Vec<_> = create_random_points_not_nan(100_000, SEED_1);
+    let tree = RTree::<_, Params>::bulk_load_with_params(points);
+    let query_point = not_nan([0.7, 0.7]);
+    c.bench_function("locate_at_point_int (unsuccessful, NotNan)", move |b| {
+        b.iter(|| tree.locate_at_point(query_point).is_none())
     });
 }
 
@@ -138,19 +197,106 @@ fn locate_unsuccessful_internal(c: &mut Criterion) {
     });
 }
 
+/// The query-heavy benchmarks, run once per scalar type.
+///
+/// A point lookup descends one root-to-leaf path and returns at the first hit; these visit many
+/// nodes and compare every candidate they reach, which is where `NotNan` can pay off -- it skips
+/// the `NaN` test that every `f64` comparison performs.
+/// Both arms must do *identical* work for the `(NotNan)` numbers to mean anything, so they share
+/// this body rather than being copy-pasted per type.
+fn query_benchmarks<P>(
+    c: &mut Criterion,
+    scalar: &str,
+    point: impl Fn([f64; 2]) -> P,
+    radius_2: P::Scalar,
+) where
+    P: rstar::Point
+        + rstar::RTreeObject<Envelope = AABB<P>>
+        + rstar::PointDistance
+        + Copy
+        + 'static,
+{
+    let points: Vec<P> = create_random_points(100_000, SEED_1)
+        .into_iter()
+        .map(&point)
+        .collect();
+    let query_points: Vec<P> = create_random_points(100, SEED_2)
+        .into_iter()
+        .map(&point)
+        .collect();
+    let envelope = AABB::from_corners(point([0.4, 0.4]), point([0.6, 0.6]));
+    let tree = RTree::<P, Params>::bulk_load_with_params(points);
+
+    let nearest_queries = query_points.clone();
+    c.bench_function(&format!("nearest_neighbor ({scalar})"), {
+        let tree = &tree;
+        move |b| {
+            b.iter(|| {
+                for query_point in &nearest_queries {
+                    tree.nearest_neighbor(*query_point).unwrap();
+                }
+            })
+        }
+    });
+
+    c.bench_function(&format!("nearest_neighbor_iter, 10 nearest ({scalar})"), {
+        let tree = &tree;
+        let query_point = query_points[0];
+        move |b| b.iter(|| tree.nearest_neighbor_iter(query_point).take(10).count())
+    });
+
+    c.bench_function(&format!("locate_in_envelope_intersecting ({scalar})"), {
+        let tree = &tree;
+        move |b| b.iter(|| tree.locate_in_envelope_intersecting(envelope).count())
+    });
+
+    c.bench_function(&format!("locate_within_distance ({scalar})"), {
+        let tree = &tree;
+        let query_point = query_points[0];
+        move |b| b.iter(|| tree.locate_within_distance(query_point, radius_2).count())
+    });
+}
+
+fn query_benchmarks_f64(c: &mut Criterion) {
+    query_benchmarks(c, "f64", |p| p, 0.01);
+}
+
+fn query_benchmarks_not_nan(c: &mut Criterion) {
+    query_benchmarks(c, "NotNan", not_nan, NotNan::new(0.01).unwrap());
+}
+
 criterion_group!(
     benches,
     bulk_load_baseline,
+    bulk_load_baseline_not_nan,
     bulk_load_comparison,
+    bulk_load_comparison_not_nan,
     bulk_load_complex_geom,
     bulk_load_complex_geom_cached,
     tree_creation_quality,
     locate_successful,
     locate_unsuccessful,
     locate_successful_internal,
+    locate_successful_internal_not_nan,
     locate_unsuccessful_internal,
+    locate_successful_not_nan,
+    locate_unsuccessful_not_nan,
+    locate_unsuccessful_internal_not_nan,
+    query_benchmarks_f64,
+    query_benchmarks_not_nan,
 );
 criterion_main!(benches);
+
+fn not_nan([x, y]: [f64; 2]) -> [NotNan<f64>; 2] {
+    [NotNan::new(x).unwrap(), NotNan::new(y).unwrap()]
+}
+
+fn create_random_points_not_nan(num_points: usize, seed: &[u8; 32]) -> Vec<[NotNan<f64>; 2]> {
+    create_random_points(num_points, seed)
+        .into_iter()
+        .map(not_nan)
+        .collect()
+}
 
 fn create_random_points(num_points: usize, seed: &[u8; 32]) -> Vec<[f64; 2]> {
     let mut rng = Hc128Rng::from_seed(*seed);

--- a/rstar-demo/Cargo.toml
+++ b/rstar-demo/Cargo.toml
@@ -3,7 +3,7 @@ name = "rstar-demo"
 version = "0.1.0"
 authors = ["Stefan Altmayer <stoeoef@gmail.com>"]
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.90"
 
 [dependencies]
 rand = "0.7"

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Unreleased
 
+## Changed
+
+- **BREAKING** `RTreeNum` no longer has a blanket implementation, and no longer requires `PartialOrd`. It now requires
+  an associated `OrdType: Ord` plus an `ord()` conversion, so that every comparison the r-tree makes is *total*, avoiding
+  problems with NaN. Implementations have been added for all common numeric types.
+  If you implement `RTreeNum` for your own scalar type, you'll need to add an implementation like:
+  ```rust
+  impl RTreeNum for MyScalar {
+      // Any `Ord` type will do; `OrderedFloat` is from the `ordered-float` crate.
+      type OrdType = ordered_float::OrderedFloat<f64>;
+      fn ord(self) -> Self::OrdType { ordered_float::OrderedFloat(self.0) }
+  }
+  ```
+  ([PR](https://github.com/georust/rstar/pull/237))
+
+## Fixed
+
+- Envelopes no longer panic on `NaN` inputs, and a `NaN` coordinate no longer strands finite points.
+  ([PR](https://github.com/georust/rstar/pull/237))
+
+[`ordered_float::OrderedFloat`]: https://docs.rs/ordered-float/latest/ordered_float/struct.OrderedFloat.html
 
 # 0.13.0
 

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 - **BREAKING** `RTreeNum` no longer has a blanket implementation, and no longer requires `PartialOrd`. It now requires
   an associated `OrdType: Ord` plus an `ord()` conversion, so that every comparison the r-tree makes is *total*, avoiding
-  problems with NaN. Implementations have been added for all common numeric types.
+  problems with NaN. Implementations have been added for all common numeric types as well as [`ordered_float::NotNan`]
   If you implement `RTreeNum` for your own scalar type, you'll need to add an implementation like:
   ```rust
   impl RTreeNum for MyScalar {
@@ -21,6 +21,7 @@
   ([PR](https://github.com/georust/rstar/pull/237))
 
 [`ordered_float::OrderedFloat`]: https://docs.rs/ordered-float/latest/ordered_float/struct.OrderedFloat.html
+[`ordered_float::NotNan`]: https://docs.rs/ordered-float/latest/ordered_float/struct.NotNan.html
 
 # 0.13.0
 

--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Changed
 
+- Increase our MSRV to Rust 1.90 following that of the `ordered-float` crate. ([PR](https://github.com/georust/rstar/pull/237))
 - **BREAKING** `RTreeNum` no longer has a blanket implementation, and no longer requires `PartialOrd`. It now requires
   an associated `OrdType: Ord` plus an `ord()` conversion, so that every comparison the r-tree makes is *total*, avoiding
   problems with NaN. Implementations have been added for all common numeric types as well as [`ordered_float::NotNan`]

--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -21,6 +21,7 @@ num-traits = { version = "0.2", default-features = false, features = ["libm"] }
 serde = { version = "1.0", optional = true, default-features = false, features = ["alloc", "derive"] }
 smallvec = "1.6"
 mint = { version = "0.5.9", optional = true }
+ordered-float = { workspace = true }
 
 [features]
 default = []

--- a/rstar/Cargo.toml
+++ b/rstar/Cargo.toml
@@ -8,7 +8,7 @@ repository = "https://github.com/georust/rstar"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.85"
+rust-version = "1.90"
 keywords = ["rtree", "r-tree", "spatial", "spatial-index", "nearest-neighbor"]
 categories = ["data-structures", "algorithms", "science::geo"]
 

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -1,4 +1,4 @@
-use crate::point::{max_inline, Point, PointExt};
+use crate::point::{max_inline, Point, PointExt, RTreeNum};
 use crate::{Envelope, RTreeObject};
 use num_traits::{Bounded, One, Zero};
 
@@ -134,17 +134,23 @@ where
     }
 
     fn is_empty(&self) -> bool {
-        self.lower.nth(0) > self.upper.nth(0)
+        self.lower.nth(0).ord() > self.upper.nth(0).ord()
     }
 
     fn contains_point(&self, point: &P) -> bool {
-        self.lower.all_component_wise(point, |x, y| x <= y)
-            && self.upper.all_component_wise(point, |x, y| x >= y)
+        self.lower
+            .all_component_wise(point, |x, y| x.ord() <= y.ord())
+            && self
+                .upper
+                .all_component_wise(point, |x, y| x.ord() >= y.ord())
     }
 
     fn contains_envelope(&self, other: &Self) -> bool {
-        self.lower.all_component_wise(&other.lower, |l, r| l <= r)
-            && self.upper.all_component_wise(&other.upper, |l, r| l >= r)
+        self.lower
+            .all_component_wise(&other.lower, |l, r| l.ord() <= r.ord())
+            && self
+                .upper
+                .all_component_wise(&other.upper, |l, r| l.ord() >= r.ord())
     }
 
     fn merge(&mut self, other: &Self) {
@@ -160,8 +166,11 @@ where
     }
 
     fn intersects(&self, other: &Self) -> bool {
-        self.lower.all_component_wise(&other.upper, |l, r| l <= r)
-            && self.upper.all_component_wise(&other.lower, |l, r| l >= r)
+        self.lower
+            .all_component_wise(&other.upper, |l, r| l.ord() <= r.ord())
+            && self
+                .upper
+                .all_component_wise(&other.lower, |l, r| l.ord() >= r.ord())
     }
 
     fn area(&self) -> P::Scalar {
@@ -178,7 +187,8 @@ where
     fn min_max_dist_2(&self, point: &P) -> <P as Point>::Scalar {
         let l = self.lower.sub(point);
         let u = self.upper.sub(point);
-        let mut max_diff = (Zero::zero(), Zero::zero(), 0); // diff, min, index
+        // diff, min, index
+        let mut max_diff: (P::Scalar, P::Scalar, usize) = (Zero::zero(), Zero::zero(), 0);
         let mut result = P::new();
 
         for i in 0..P::DIMENSIONS {
@@ -186,14 +196,14 @@ where
             let mut max = u.nth(i);
             max = max * max;
             min = min * min;
-            if max < min {
+            if max.ord() < min.ord() {
                 core::mem::swap(&mut min, &mut max);
             }
 
             let diff = max - min;
             *result.nth_mut(i) = max;
 
-            if diff >= max_diff.0 {
+            if diff.ord() >= max_diff.0.ord() {
                 max_diff = (diff, min, i);
             }
         }
@@ -227,8 +237,8 @@ where
             l.envelope()
                 .lower
                 .nth(axis)
-                .partial_cmp(&r.envelope().lower.nth(axis))
-                .unwrap()
+                .ord()
+                .cmp(&r.envelope().lower.nth(axis).ord())
         });
     }
 
@@ -241,8 +251,8 @@ where
             l.envelope()
                 .lower
                 .nth(axis)
-                .partial_cmp(&r.envelope().lower.nth(axis))
-                .unwrap()
+                .ord()
+                .cmp(&r.envelope().lower.nth(axis).ord())
         });
     }
 }

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -378,4 +378,91 @@ mod test {
         tree.insert([-0.0f64, -0.0]);
         assert_eq!(tree.locate_at_point([0.0f64, 0.0]), Some(&[-0.0, -0.0]));
     }
+
+    #[test]
+    fn not_nan_coordinates_are_supported() {
+        use ordered_float::NotNan;
+
+        let point = |x: f64, y: f64| [NotNan::new(x).unwrap(), NotNan::new(y).unwrap()];
+
+        let mut tree = RTree::new();
+        for value in 0..32 {
+            tree.insert(point(value as f64, (value * 2) as f64));
+        }
+
+        assert_eq!(tree.size(), 32);
+        assert_eq!(
+            tree.locate_at_point(point(10.0, 20.0)),
+            Some(&point(10.0, 20.0))
+        );
+        assert_eq!(
+            tree.nearest_neighbor(point(10.4, 20.0)),
+            Some(&point(10.0, 20.0))
+        );
+        assert_eq!(tree.locate_at_point(point(0.5, 0.5)), None);
+    }
+
+    // document some known panic cases with NotNan
+    mod known_panics {
+        use super::*;
+
+        #[test]
+        #[should_panic(expected = "resulted in NaN")]
+        fn infinite_not_nan_coordinates_panic() {
+            use ordered_float::NotNan;
+
+            let point = |x: f64, y: f64| [NotNan::new(x).unwrap(), NotNan::new(y).unwrap()];
+            let infinite = point(f64::INFINITY, 0.0);
+
+            let mut tree = RTree::new();
+            tree.insert(infinite);
+            tree.insert(point(0.0, 0.0));
+
+            // This line panics. Measuring the distance from the query point to the point at infinity computes
+            // `inf - inf`, which is `NaN`.
+            tree.nearest_neighbor(infinite);
+        }
+
+        /// `area` multiplies the envelope's
+        /// extents together, once per dimension, so in 3-D any extent beyond the cube root of
+        /// `f32::MAX` (7e12) gives `inf`. `choose_subtree` subtracts two such areas, and `inf - inf`
+        /// is `NaN` -- though every coordinate below is finite and well inside `f32::MAX` (3.4e38).
+        #[test]
+        #[should_panic(expected = "resulted in NaN")]
+        fn overflowing_not_nan_coordinates_panic() {
+            use ordered_float::NotNan;
+
+            let point = |i: u32| {
+                let v = 1e13 * i as f32;
+                [
+                    NotNan::new(v).unwrap(),
+                    NotNan::new(-v).unwrap(),
+                    NotNan::new(v / 2.0).unwrap(),
+                ]
+            };
+
+            let mut tree = RTree::new();
+            for i in 0..8 {
+                tree.insert(point(i));
+            }
+        }
+
+        /// The likelier failure in practice needs no extreme magnitudes at all: `nearest_point`
+        /// divides by the line's squared length, so a segment whose endpoints coincide -- a polyline
+        /// with a duplicated vertex -- divides `0.0 / 0.0` while answering a query.
+        #[test]
+        #[should_panic(expected = "resulted in NaN")]
+        fn degenerate_not_nan_line_panics() {
+            use crate::primitives::Line;
+            use ordered_float::NotNan;
+
+            let n = |v: f64| NotNan::new(v).unwrap();
+
+            let mut tree = RTree::new();
+            tree.insert(Line::new([n(0.0), n(0.0)], [n(1.0), n(1.0)]));
+            tree.insert(Line::new([n(2.0), n(2.0)], [n(2.0), n(2.0)]));
+
+            tree.nearest_neighbor([n(2.0), n(3.0)]);
+        }
+    }
 }

--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -252,6 +252,7 @@ mod test {
     use super::AABB;
     use crate::envelope::Envelope;
     use crate::object::PointDistance;
+    use crate::RTree;
 
     #[test]
     fn empty_rect() {
@@ -300,5 +301,71 @@ mod test {
 
         let not_empty = AABB::from_corners([1.0, 1.0], [1.0, 1.0]);
         assert!(!not_empty.is_empty());
+    }
+
+    #[test]
+    fn rtree_operations_with_nan_do_not_panic() {
+        let mut points: Vec<_> = (0..64).map(|value| [value as f64, value as f64]).collect();
+        points[16][0] = f64::NAN;
+
+        let tree = RTree::bulk_load(points.clone());
+        assert_eq!(tree.size(), points.len());
+        assert_eq!(
+            tree.nearest_neighbor_iter([f64::NAN, 0.0]).count(),
+            points.len()
+        );
+
+        let mut tree = RTree::new();
+        for point in &points {
+            tree.insert(*point);
+        }
+
+        assert_eq!(tree.size(), points.len());
+        assert_eq!(
+            tree.nearest_neighbor_iter([f64::NAN, 0.0]).count(),
+            points.len()
+        );
+    }
+
+    #[test]
+    fn tree_with_nan_is_still_queryable() {
+        let before_the_nan = [10.0, 0.0];
+        let after_the_nan = [20.0, 0.0];
+
+        let mut tree = RTree::new();
+        tree.insert(before_the_nan);
+        tree.insert([f64::NAN, 0.0]);
+        tree.insert(after_the_nan);
+
+        assert_eq!(tree.size(), 3);
+        assert_eq!(tree.iter().count(), 3);
+
+        assert_eq!(tree.locate_at_point(before_the_nan), Some(&before_the_nan));
+        assert_eq!(tree.locate_at_point(after_the_nan), Some(&after_the_nan));
+
+        assert!(tree.contains(&before_the_nan));
+        assert!(tree.contains(&after_the_nan));
+
+        assert_eq!(tree.remove(&before_the_nan), Some(before_the_nan));
+        assert_eq!(tree.remove(&after_the_nan), Some(after_the_nan));
+    }
+
+    /// `-0.0` and `0.0` are the same point as far as `==` is concerned, so a query for
+    /// one must find data inserted under the other.
+    ///
+    /// This is why the scalar ordering is `OrderedFloat` rather than `f64::total_cmp`:
+    /// which would rank `-0.0` strictly below `0.0`.
+    #[test]
+    fn signed_zeroes_are_interchangeable_in_queries() {
+        let envelope = AABB::from_corners([0.0f64, 0.0], [1.0, 1.0]);
+        assert!(envelope.contains_point(&[-0.0f64, -0.0]));
+
+        let mut tree = RTree::new();
+        tree.insert([0.0f64, 0.0]);
+        assert_eq!(tree.locate_at_point([-0.0f64, -0.0]), Some(&[0.0, 0.0]));
+
+        let mut tree = RTree::new();
+        tree.insert([-0.0f64, -0.0]);
+        assert_eq!(tree.locate_at_point([0.0f64, 0.0]), Some(&[-0.0, -0.0]));
     }
 }

--- a/rstar/src/algorithm/nearest_neighbor.rs
+++ b/rstar/src/algorithm/nearest_neighbor.rs
@@ -1,4 +1,4 @@
-use crate::point::min_inline;
+use crate::point::{min_inline, RTreeNum};
 use crate::{
     node::{ParentNode, RTreeNode},
     object::Distance,
@@ -28,7 +28,9 @@ where
     T: PointDistance,
 {
     fn eq(&self, other: &Self) -> bool {
-        self.distance == other.distance
+        // Not `self.distance == other.distance`: that leaves `Eq` inconsistent with the
+        // `Ord` impl below, which reports two NaN distances as equal.
+        self.distance.ord() == other.distance.ord()
     }
 }
 
@@ -49,7 +51,7 @@ where
 {
     fn cmp(&self, other: &Self) -> ::core::cmp::Ordering {
         // Inverse comparison creates a min heap
-        other.distance.partial_cmp(&self.distance).unwrap()
+        other.distance.ord().cmp(&self.distance.ord())
     }
 }
 
@@ -248,7 +250,7 @@ where
             let distance_if_less_or_equal = match child {
                 RTreeNode::Parent(ref data) => {
                     let distance = data.envelope.distance_2(query_point);
-                    if distance <= *min_max_distance {
+                    if distance.ord() <= min_max_distance.ord() {
                         Some(distance)
                     } else {
                         None

--- a/rstar/src/algorithm/rstar.rs
+++ b/rstar/src/algorithm/rstar.rs
@@ -1,7 +1,7 @@
 use crate::node::{envelope_for_children, ParentNode, RTreeNode};
 use crate::object::RTreeObject;
 use crate::params::{InsertionStrategy, RTreeParams};
-use crate::point::{Point, PointExt};
+use crate::point::{Point, PointExt, RTreeNum};
 use crate::rtree::RTree;
 use crate::{envelope::Envelope, object::Distance};
 
@@ -170,7 +170,7 @@ where
         if envelope.contains_envelope(&insertion_envelope) {
             inclusion_count += 1;
             let area = envelope.area();
-            if area < min_area {
+            if area.ord() < min_area.ord() {
                 min_area = area;
                 min_index = index;
             }
@@ -178,7 +178,7 @@ where
     }
     if inclusion_count == 0 {
         // No inclusion found, subtree depends on overlap and area increase
-        let mut min = (zero, zero, zero);
+        let mut min = (zero.ord(), zero.ord(), zero.ord());
 
         for (index1, child1) in node.children.iter().enumerate() {
             let envelope = child1.envelope();
@@ -205,7 +205,7 @@ where
             // Calculate area increase and area
             let area = new_envelope.area();
             let area_increase = area - envelope.area();
-            let new_min = (overlap_increase, area_increase, area);
+            let new_min = (overlap_increase.ord(), area_increase.ord(), area.ord());
             if new_min < min || index1 == 0 {
                 min = new_min;
                 min_index = index1;
@@ -254,7 +254,7 @@ where
     debug_assert!(node.children.len() >= 2);
     // Sort along axis
     T::Envelope::sort_envelopes(axis, &mut node.children);
-    let mut best = (zero, zero);
+    let mut best = (zero.ord(), zero.ord());
     let min_size = Params::MIN_SIZE;
     let mut best_index = min_size;
 
@@ -271,7 +271,7 @@ where
 
         let overlap_value = first_envelope.intersection_area(&second_envelope);
         let area_value = first_envelope.area() + second_envelope.area();
-        let new_best = (overlap_value, area_value);
+        let new_best = (overlap_value.ord(), area_value.ord());
         if new_best < best || k == min_size {
             best = new_best;
             best_index = k;
@@ -287,7 +287,7 @@ where
     T: RTreeObject,
     Params: RTreeParams,
 {
-    let mut best_goodness = Distance::<T>::max_value();
+    let mut best_goodness = Distance::<T>::max_value().ord();
     let mut best_axis = 0;
     let min_size = Params::MIN_SIZE;
     let until = node.children.len() - min_size + 1;
@@ -315,9 +315,9 @@ where
 
             let perimeter_value =
                 first_modified.perimeter_value() + second_modified.perimeter_value();
-            if best_goodness > perimeter_value {
+            if best_goodness > perimeter_value.ord() {
                 best_axis = axis;
-                best_goodness = perimeter_value;
+                best_goodness = perimeter_value.ord();
             }
         }
     }
@@ -337,8 +337,8 @@ where
         l_center
             .sub(&center)
             .length_2()
-            .partial_cmp(&(r_center.sub(&center)).length_2())
-            .unwrap()
+            .ord()
+            .cmp(&r_center.sub(&center).length_2().ord())
     });
     let num_children = node.children.len();
     let result = node

--- a/rstar/src/algorithm/selection_functions.rs
+++ b/rstar/src/algorithm/selection_functions.rs
@@ -1,6 +1,6 @@
 use crate::object::PointDistance;
 use crate::object::RTreeObject;
-use crate::{envelope::Envelope, object::Distance};
+use crate::{envelope::Envelope, object::Distance, RTreeNum};
 
 /// Advanced trait to iterate through an r-tree. Usually it should not be required to be implemented.
 ///
@@ -197,7 +197,7 @@ where
 {
     fn should_unpack_parent(&self, parent_envelope: &T::Envelope) -> bool {
         let envelope_distance = parent_envelope.distance_2(&self.circle_origin);
-        envelope_distance <= self.squared_max_distance
+        envelope_distance.ord() <= self.squared_max_distance.ord()
     }
 
     fn should_unpack_leaf(&self, leaf: &T) -> bool {

--- a/rstar/src/object.rs
+++ b/rstar/src/object.rs
@@ -4,6 +4,7 @@ use alloc::sync::Arc;
 use crate::aabb::AABB;
 use crate::envelope::Envelope;
 use crate::point::{Point, PointExt};
+use crate::RTreeNum;
 
 /// Type alias for distance scalar types derived from `PointDistance` objects
 #[allow(type_alias_bounds)]
@@ -167,7 +168,7 @@ pub trait PointDistance: RTreeObject {
     /// contained within `self`. Changing this default behavior is advised if calculating the squared distance
     /// is more computationally expensive than a point containment check.
     fn contains_point(&self, point: &<Self::Envelope as Envelope>::Point) -> bool {
-        self.distance_2(point) <= num_traits::zero()
+        self.distance_2(point).ord() <= num_traits::zero::<Distance<Self>>().ord()
     }
 
     /// Returns the squared distance to this object, or `None` if the distance
@@ -189,9 +190,9 @@ pub trait PointDistance: RTreeObject {
         max_distance_2: Distance<Self>,
     ) -> Option<Distance<Self>> {
         let envelope_distance = self.envelope().distance_2(point);
-        if envelope_distance <= max_distance_2 {
+        if envelope_distance.ord() <= max_distance_2.ord() {
             let distance_2 = self.distance_2(point);
-            if distance_2 <= max_distance_2 {
+            if distance_2.ord() <= max_distance_2.ord() {
                 return Some(distance_2);
             }
         }
@@ -228,7 +229,7 @@ where
         max_distance_2: Distance<Self>,
     ) -> Option<P::Scalar> {
         let distance_2 = <Self as PointExt>::distance_2(self, point);
-        if distance_2 <= max_distance_2 {
+        if distance_2.ord() <= max_distance_2.ord() {
             Some(distance_2)
         } else {
             None

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -1,5 +1,7 @@
 use core::fmt::Debug;
+use core::num::Wrapping;
 use num_traits::{Bounded, Num, Signed, Zero};
+use ordered_float::OrderedFloat;
 
 /// Defines a number type that is compatible with rstar.
 ///
@@ -8,13 +10,15 @@ use num_traits::{Bounded, Num, Signed, Zero};
 ///  - [Wrapping](core::num::Wrapping) versions of the above
 ///  - f32, f64
 ///
-/// This type cannot be implemented directly. Instead, it is required to implement
-/// all required traits from the `num_traits` crate.
+/// r-trees require a *total* order on their scalars.
+/// [`RTreeNum::OrdType`] supplies that ordering. Integral types, which are already Ord,
+/// are their own OrdType. `f32` and `f64` use [`ordered_float::OrderedFloat`].
 ///
 /// # Example
 /// ```
 /// # extern crate num_traits;
 /// use num_traits::{Bounded, Num, Signed};
+/// use rstar::RTreeNum;
 ///
 /// #[derive(Clone, Copy, PartialEq, PartialOrd, Debug)]
 /// struct MyFancyNumberType(f32);
@@ -43,6 +47,12 @@ use num_traits::{Bounded, Num, Signed, Zero};
 ///   // ... details hidden ...
 /// # type FromStrRadixErr = num_traits::ParseFloatError;
 /// # fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> { unimplemented!() }
+/// }
+///
+/// impl RTreeNum for MyFancyNumberType {
+///   // Any `Ord` type will do; `OrderedFloat` is from the `ordered-float` crate.
+///   type OrdType = ordered_float::OrderedFloat<f32>;
+///   fn ord(self) -> Self::OrdType { ordered_float::OrderedFloat(self.0) }
 /// }
 ///
 /// // Lots of traits are still missing to make the above code compile, but
@@ -95,9 +105,146 @@ use num_traits::{Bounded, Num, Signed, Zero};
 /// #
 /// ```
 ///
-pub trait RTreeNum: Bounded + Num + Clone + Copy + Signed + PartialOrd + Debug {}
+pub trait RTreeNum: Bounded + Num + Clone + Copy + Signed + Debug {
+    /// A type that orders values of `Self` *totally*, i.e. any two values can be
+    /// compared and the comparison is reflexive, antisymmetric and transitive.
+    ///
+    /// For integral types this is simply `Self`. Floating point types use
+    /// [`OrderedFloat`] to account for NaN.
+    type OrdType: Ord;
 
-impl<S> RTreeNum for S where S: Bounded + Num + Clone + Copy + Signed + PartialOrd + Debug {}
+    /// Converts `self` into a value that can be ordered totally.
+    ///
+    /// ```
+    /// use rstar::RTreeNum;
+    ///
+    /// assert!(!(f64::NAN <= f64::NAN));           // PartialOrd: refuses to order the pair
+    /// assert!(f64::NAN.ord() <= f64::NAN.ord());  // Ord: always commits to an answer
+    /// ```
+    fn ord(self) -> Self::OrdType;
+}
+
+impl RTreeNum for f32 {
+    type OrdType = OrderedFloat<Self>;
+    #[inline]
+    fn ord(self) -> Self::OrdType {
+        OrderedFloat(self)
+    }
+}
+
+impl RTreeNum for f64 {
+    type OrdType = OrderedFloat<Self>;
+    #[inline]
+    fn ord(self) -> Self::OrdType {
+        OrderedFloat(self)
+    }
+}
+
+macro_rules! impl_rtree_num_for_ord {
+    ($($type:ty),+ $(,)?) => {
+        $(
+            impl RTreeNum for $type {
+                type OrdType = $type;
+                #[inline]
+                fn ord(self) -> Self::OrdType {
+                    self
+                }
+            }
+        )+
+    };
+}
+
+// Keep this list in sync with `tests::test_types`, which asserts these types implement `RTreeNum`.
+impl_rtree_num_for_ord!(i8, i16, i32, i64, i128, isize);
+
+impl<T> RTreeNum for Wrapping<T>
+where
+    T: RTreeNum,
+    Wrapping<T>: Bounded + Num + Clone + Copy + Signed + Debug,
+{
+    type OrdType = T::OrdType;
+    #[inline]
+    fn ord(self) -> Self::OrdType {
+        self.0.ord()
+    }
+}
+
+#[cfg(test)]
+mod rtree_num_tests {
+    use super::RTreeNum;
+    use core::cmp::Ordering;
+
+    /// Away from `-0.0` and `-NaN`, [`RTreeNum::ord`] agrees with the platform's
+    /// intrinsic total order. Those two values are the only deliberate divergences, so
+    /// callers of this helper must leave them out of `values` on purpose, not by
+    /// accident. They are covered by the two tests below.
+    fn assert_matches_intrinsic_total_cmp<S: RTreeNum + core::fmt::Debug>(
+        values: &[S],
+        intrinsic_total_cmp: impl Fn(&S, &S) -> Ordering,
+    ) {
+        for left in values {
+            for right in values {
+                assert_eq!(
+                    left.ord().cmp(&right.ord()),
+                    intrinsic_total_cmp(left, right),
+                    "unexpected ordering for {left:?} and {right:?}",
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn ord_matches_f32_intrinsic_total_cmp() {
+        assert_matches_intrinsic_total_cmp(
+            &[f32::NEG_INFINITY, -1.0, 0.0, 1.0, f32::INFINITY, f32::NAN],
+            f32::total_cmp,
+        );
+    }
+
+    #[test]
+    fn ord_matches_f64_intrinsic_total_cmp() {
+        assert_matches_intrinsic_total_cmp(
+            &[f64::NEG_INFINITY, -1.0, 0.0, 1.0, f64::INFINITY, f64::NAN],
+            f64::total_cmp,
+        );
+    }
+
+    /// Every `NaN` ranks above every other value and equal to every other `NaN`,
+    /// whatever its sign bit. This is what keeps a `NaN` coordinate *conservative*: it
+    /// always loses a `min` and always wins a `max`, so it can only widen an envelope's
+    /// upper bound, never shrink a bound inwards and strand the finite children already
+    /// merged in.
+    ///
+    /// [`f64::total_cmp`] does not have this property -- it sorts `-NaN` below
+    /// `-inf` -- which would let an arbitrary `NaN`'s sign bit decide which end of the
+    /// envelope it corrupted.
+    #[test]
+    fn every_nan_ranks_highest_regardless_of_sign() {
+        for nan in [f64::NAN, -f64::NAN] {
+            for other in [f64::NEG_INFINITY, -1.0, 0.0, 1.0, f64::INFINITY] {
+                assert_eq!(nan.ord().cmp(&other.ord()), Ordering::Greater);
+                assert_eq!(other.ord().cmp(&nan.ord()), Ordering::Less);
+            }
+            // Reflexive, unlike `<=`, which is what makes this usable as a comparator.
+            assert_eq!(nan.ord().cmp(&nan.ord()), Ordering::Equal);
+            assert_eq!(nan.ord().cmp(&(-nan).ord()), Ordering::Equal);
+        }
+    }
+
+    /// `-0.0` and `0.0` must stay *equal*, as they are under `==`.
+    ///
+    /// [`f64::total_cmp`] ranks `-0.0` strictly below `0.0`. Since every comparison in
+    /// the tree now goes through this ordering, adopting that behaviour would mean an
+    /// envelope with a lower bound of `0.0` no longer contains the point `-0.0`. See
+    /// `signed_zeroes_are_interchangeable_in_queries` in `aabb.rs`.
+    #[test]
+    fn signed_zeroes_compare_equal() {
+        assert_eq!((-0.0f64).ord().cmp(&0.0f64.ord()), Ordering::Equal);
+        assert_eq!((-0.0f32).ord().cmp(&0.0f32.ord()), Ordering::Equal);
+
+        assert_eq!(f64::total_cmp(&-0.0, &0.0), Ordering::Less);
+    }
+}
 
 /// Defines a point type that is compatible with rstar.
 ///
@@ -273,7 +420,7 @@ pub fn min_inline<S>(a: S, b: S) -> S
 where
     S: RTreeNum,
 {
-    if a < b {
+    if a.ord() < b.ord() {
         a
     } else {
         b
@@ -285,7 +432,7 @@ pub fn max_inline<S>(a: S, b: S) -> S
 where
     S: RTreeNum,
 {
-    if a > b {
+    if a.ord() > b.ord() {
         a
     } else {
         b

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -1,7 +1,7 @@
 use core::fmt::Debug;
 use core::num::Wrapping;
 use num_traits::{Bounded, Num, Signed, Zero};
-use ordered_float::OrderedFloat;
+use ordered_float::{NotNan, OrderedFloat};
 
 /// Defines a number type that is compatible with rstar.
 ///
@@ -137,6 +137,84 @@ impl RTreeNum for f64 {
     #[inline]
     fn ord(self) -> Self::OrdType {
         OrderedFloat(self)
+    }
+}
+
+/// `NotNan` has ruled `NaN` out by construction, so comparisons skip the `NaN` test that
+/// every `f32`/`f64` comparison performs. Building a tree over `[NotNan<f64>; 2]`
+/// moves that cost onto the one-time construction of the coordinates, which pays off
+/// for query-heavy workloads over well-formed input.
+///
+/// ```
+/// use ordered_float::NotNan;
+/// use rstar::RTree;
+///
+/// let point = |x: f64, y: f64| [NotNan::new(x).unwrap(), NotNan::new(y).unwrap()];
+///
+/// let tree = RTree::bulk_load(vec![
+///     point(0.0, 0.0),
+///     point(10.0, 20.0),
+///     point(-3.0, 4.5),
+/// ]);
+///
+/// assert_eq!(tree.locate_at_point(point(0.0, 0.0)), Some(&point(0.0, 0.0)));
+/// assert_eq!(
+///     tree.nearest_neighbor(point(10.4, 20.0)),
+///     Some(&point(10.0, 20.0)),
+/// );
+/// ```
+///
+/// In exchange, `NotNan` re-validates every arithmetic result and **panics** if one
+/// is `NaN`. The r-tree does arithmetic on coordinates as well as comparing them,
+/// and its intermediates leave the range of the input, so ordinary-looking
+/// coordinates can reach a `NaN`:
+///
+/// - **Large coordinates.** [`area`](crate::Envelope::area) multiplies one extent
+///   per dimension, so in 3-D an extent past the cube root of `f32::MAX` (7e12)
+///   gives `inf`. Insertion subtracts two such areas, and `inf - inf` is `NaN`.
+/// - **Tiny or degenerate geometry.** [`Line::nearest_point`](crate::primitives::Line::nearest_point)
+///   divides by the line's squared length. Two identical endpoints -- a duplicated
+///   vertex in a polyline -- make that `0.0 / 0.0`, and so does a line short enough
+///   that its squared length underflows to zero.
+///
+/// An `f32`/`f64` tree computes the same `NaN`s without panicking: they misinform a
+/// heuristic, but the total order keeps every comparison well defined.
+///
+/// ```should_panic
+/// use ordered_float::NotNan;
+/// use rstar::RTree;
+///
+/// // Finite coordinates, four orders of magnitude clear of `f32::MAX`.
+/// let point = |i: u32| {
+///     let v = 1e13 * i as f32;
+///     [
+///         NotNan::new(v).unwrap(),
+///         NotNan::new(-v).unwrap(),
+///         NotNan::new(v / 2.0).unwrap(),
+///     ]
+/// };
+///
+/// let mut tree = RTree::new();
+/// for i in 0..8 {
+///     // Panics once two envelope areas overflow to `inf`: `inf - inf` is `NaN`.
+///     tree.insert(point(i));
+/// }
+/// ```
+impl RTreeNum for NotNan<f64> {
+    type OrdType = Self;
+    #[inline]
+    fn ord(self) -> Self::OrdType {
+        self
+    }
+}
+
+/// The `f32` counterpart of the `NotNan<f64>` implementation above; see its documentation for
+/// what this scalar buys, and for the cases where the r-tree's own arithmetic panics.
+impl RTreeNum for NotNan<f32> {
+    type OrdType = Self;
+    #[inline]
+    fn ord(self) -> Self::OrdType {
+        self
     }
 }
 

--- a/rstar/src/primitives/line.rs
+++ b/rstar/src/primitives/line.rs
@@ -2,6 +2,7 @@ use crate::envelope::Envelope;
 use crate::object::PointDistance;
 use crate::object::RTreeObject;
 use crate::point::{Point, PointExt};
+use crate::RTreeNum;
 use crate::{aabb::AABB, object::Distance};
 use num_traits::{One, Zero};
 
@@ -93,9 +94,9 @@ where
         let (p1, p2) = (self.from.clone(), self.to.clone());
         let dir = p2.sub(&p1);
         let s = self.project_point(query_point);
-        if P::Scalar::zero() < s && s < One::one() {
+        if P::Scalar::zero().ord() < s.ord() && s.ord() < P::Scalar::one().ord() {
             p1.add(&dir.mul(s))
-        } else if s <= P::Scalar::zero() {
+        } else if s.ord() <= P::Scalar::zero().ord() {
             p1
         } else {
             p2

--- a/rstar/src/primitives/rectangle.rs
+++ b/rstar/src/primitives/rectangle.rs
@@ -1,6 +1,7 @@
 use crate::envelope::Envelope;
 use crate::object::{PointDistance, RTreeObject};
 use crate::point::{Point, PointExt};
+use crate::RTreeNum;
 use crate::{aabb::AABB, object::Distance};
 
 /// An n-dimensional rectangle defined by its two corners.
@@ -102,7 +103,7 @@ where
         max_distance_2: Distance<Self>,
     ) -> Option<Distance<Self>> {
         let distance_2 = self.distance_2(point);
-        if distance_2 <= max_distance_2 {
+        if distance_2.ord() <= max_distance_2.ord() {
             Some(distance_2)
         } else {
             None


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Fixes https://github.com/georust/rstar/issues/112

Our old friend, NaN. I noticed this while trying to use the [new (unreleased) validation feature](https://github.com/georust/geo/pull/1522) in geo which can panic when attempting to validate Polygons with NaN in their interior.

This is one of those cases where we swap a `--release` panic for potentially giving incorrect / unexpected results. Is it a good idea? Reasonable minds may disagree! But panic'ing in `release` mode is a pretty serious offense.