### PR TITLE
fix demo deps

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,11 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Check formatting using Rustfmt
         run: cargo fmt --all --check
-      - name: Check workspace
+      - name: Check main crate
+        run: cargo check --package rstar --all-targets
+      - name: Check bench and demo crates (warn only)
         run: cargo check --workspace --all-targets
+        continue-on-error: true
       - name: Lint using Clippy
         run: cargo clippy --workspace --exclude rstar-demo --tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,8 +46,6 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Check formatting using Rustfmt
         run: cargo fmt --all --check
-      - name: Check main crate
-        run: cargo check --package rstar --all-targets
       - name: Lint using Clippy
         run: cargo clippy --workspace --exclude rstar-demo --tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,6 +46,8 @@ jobs:
         uses: Swatinem/rust-cache@v2
       - name: Check formatting using Rustfmt
         run: cargo fmt --all --check
+      - name: Check workspace
+        run: cargo check --workspace --all-targets
       - name: Lint using Clippy
         run: cargo clippy --workspace --exclude rstar-demo --tests
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,11 +48,26 @@ jobs:
         run: cargo fmt --all --check
       - name: Check main crate
         run: cargo check --package rstar --all-targets
-      - name: Check bench and demo crates (warn only)
-        run: cargo check --workspace --all-targets
-        continue-on-error: true
       - name: Lint using Clippy
         run: cargo clippy --workspace --exclude rstar-demo --tests
+
+  check_aux:
+    # Informational only: these crates aren't published, and their dependencies
+    # break more often than we care to fix. Deliberately excluded from the
+    # `conclusion` job, so a failure here won't block merging.
+    name: Check bench and demo crates
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+      - name: Install stable toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Setup Rust cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: check-aux
+      - name: Check bench and demo crates
+        run: cargo check --package rstar-benches --package rstar-demo --all-targets
 
   msrv:
     name: MSRV build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -145,7 +145,7 @@ checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -663,7 +663,7 @@ checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -758,7 +758,7 @@ checksum = "1a5c6c585bc94aaf2c7b51dd4c2ba22680844aba4c687be581871a6f518c5742"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1247,7 +1247,7 @@ checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1301,7 +1301,7 @@ dependencies = [
  "quote",
  "rustc_version",
  "simd_cesu8",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1329,7 +1329,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1375,7 +1375,7 @@ dependencies = [
  "image",
  "instant",
  "kiss3d-macro",
- "nalgebra 0.34.2",
+ "nalgebra",
  "num-traits",
  "oneshot",
  "parry3d",
@@ -1397,7 +1397,7 @@ checksum = "a5a36382c6543d11c3ce4928eff122001a9fd3fc0096c305beb5ed2486cc0d72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1552,22 +1552,6 @@ dependencies = [
 
 [[package]]
 name = "nalgebra"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fb2d0de08694bed883320212c18ee3008576bfe8c306f4c3c4a58b4876998be"
-dependencies = [
- "approx",
- "matrixmultiply",
- "nalgebra-macros 0.1.0",
- "num-complex",
- "num-rational",
- "num-traits",
- "simba 0.7.3",
- "typenum",
-]
-
-[[package]]
-name = "nalgebra"
 version = "0.34.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df76ea0ff5c7e6b88689085804d6132ded0ddb9de5ca5b8aeb9eeadc0508a70a"
@@ -1593,23 +1577,12 @@ dependencies = [
  "glam 0.32.1",
  "matrixmultiply",
  "mint",
- "nalgebra-macros 0.3.0",
+ "nalgebra-macros",
  "num-complex",
  "num-rational",
  "num-traits",
- "simba 0.9.1",
+ "simba",
  "typenum",
-]
-
-[[package]]
-name = "nalgebra-macros"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "01fcc0b8149b4632adc89ac3b7b31a12fb6099a0317a4eb2ebff574ef7de7218"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -1620,7 +1593,7 @@ checksum = "973e7178a678cfd059ccec50887658d482ce16b0aa9da3888ddeab5cd5eb4889"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1710,7 +1683,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1772,7 +1745,7 @@ dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2101,12 +2074,12 @@ dependencies = [
  "foldhash 0.2.0",
  "hashbrown 0.16.1",
  "log",
- "nalgebra 0.34.2",
+ "nalgebra",
  "num-derive",
  "num-traits",
  "ordered-float",
  "rstar 0.12.2",
- "simba 0.9.1",
+ "simba",
  "slab",
  "smallvec",
  "spade",
@@ -2149,7 +2122,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2247,7 +2220,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2284,7 +2257,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
 dependencies = [
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2593,7 +2566,7 @@ dependencies = [
  "approx",
  "heapless",
  "mint",
- "nalgebra 0.34.2",
+ "nalgebra",
  "num-traits",
  "rand 0.10.1",
  "rand_hc 0.5.0",
@@ -2617,7 +2590,7 @@ name = "rstar-demo"
 version = "0.1.0"
 dependencies = [
  "kiss3d",
- "nalgebra 0.30.1",
+ "nalgebra",
  "rand 0.7.3",
  "rstar 0.13.0",
 ]
@@ -2754,7 +2727,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2775,19 +2748,6 @@ name = "shlex"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
-
-[[package]]
-name = "simba"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f3fd720c48c53cace224ae62bef1bbff363a70c68c4802a78b5cc6159618176"
-dependencies = [
- "approx",
- "num-complex",
- "num-traits",
- "paste",
- "wide",
-]
 
 [[package]]
 name = "simba"
@@ -2920,17 +2880,6 @@ checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -2966,7 +2915,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2977,7 +2926,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -3204,7 +3153,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -3621,7 +3570,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -3637,7 +3586,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -3765,7 +3714,7 @@ checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]

--- a/rstar-demo/Cargo.toml
+++ b/rstar-demo/Cargo.toml
@@ -3,7 +3,7 @@ name = "rstar-demo"
 version = "0.1.0"
 authors = ["Stefan Altmayer <stoeoef@gmail.com>"]
 edition = "2021"
-rust-version = "1.68"
+rust-version = "1.85"
 
 [dependencies]
 rand = "0.7"
@@ -13,6 +13,6 @@ rand = "0.7"
 # kiss3d = "0.31"
 # nalgebra = "0.26"
 kiss3d = "0.37.1"
-nalgebra = "0.30"
+nalgebra = "0.34"
 
 rstar = { path="../rstar" }

--- a/rstar-demo/src/main.rs
+++ b/rstar-demo/src/main.rs
@@ -109,7 +109,8 @@ pub enum RenderData {
     TwoD(Vec<two_d::LineRenderData2D>),
 }
 
-fn main() {
+#[kiss3d::main]
+async fn main() {
     const WINDOW_WIDTH: u32 = 1024;
     const WINDOW_HEIGHT: u32 = 768;
     let mut window = Window::new_with_size("RStar demo", WINDOW_WIDTH, WINDOW_HEIGHT);
@@ -121,7 +122,10 @@ fn main() {
 
     let mut render_data = create_render_data_from_scene(&scene);
 
-    while window.render_with_cameras(&mut scene.camera_3d, &mut scene.camera_2d) {
+    while window
+        .render_with_cameras(&mut scene.camera_3d, &mut scene.camera_2d)
+        .await
+    {
         render_data = handle_input(&window, &mut scene).unwrap_or(render_data);
         draw_tree(&mut window, &render_data);
         draw_help(&mut window, scene.render_mode);

--- a/rstar-demo/src/main.rs
+++ b/rstar-demo/src/main.rs
@@ -141,6 +141,7 @@ fn create_default_camera_2d() -> Sidescroll {
 }
 
 pub fn create_random_points<P: Point<Scalar = f32>>(num_points: usize) -> Vec<P> {
+    let _this_will_not_compile: () = "deliberately broken for CI testing";
     let mut result = Vec::with_capacity(num_points);
     let mut rng = rand::thread_rng();
     let distribution = Uniform::new(-1.0f32, 1.0);

--- a/rstar-demo/src/main.rs
+++ b/rstar-demo/src/main.rs
@@ -141,7 +141,6 @@ fn create_default_camera_2d() -> Sidescroll {
 }
 
 pub fn create_random_points<P: Point<Scalar = f32>>(num_points: usize) -> Vec<P> {
-    let _this_will_not_compile: () = "deliberately broken for CI testing";
     let mut result = Vec::with_capacity(num_points);
     let mut rng = rand::thread_rng();
     let distribution = Uniform::new(-1.0f32, 1.0);


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

Edit: note this is based on https://github.com/georust/rstar/pull/232 so merge that first.

`cargo test` / `cargo check` of the workspace currently fails.

Potentially (?) controversial is adding `cargo check` (of the demo) to CI. It could be potentially annoying to have the demo block merging of other work. It's also annoying now that I can't run `cargo check` in the workspace because the demo is broken. 🤷 I'm open to omitting the second commit.

