### PR TITLE
fix(bulk_load): keep all leaves on the same depth

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Fixed
+- Fixed `bulk_load` building trees whose leaves were not all on the same depth. Depending on the element count this produced a malformed R-tree, which could make a subsequent `insert` panic with "This is a bug in rstar.". `bulk_load` now places all leaves on the same level.
+
 
 # 0.13.0
 

--- a/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
+++ b/rstar/src/algorithm/bulk_load/bulk_load_sequential.rs
@@ -12,14 +12,54 @@ use num_traits::Float;
 
 use super::cluster_group_iterator::{calculate_number_of_clusters_on_axis, ClusterGroupIterator};
 
-fn bulk_load_recursive<T, Params>(mut elements: Vec<T>) -> ParentNode<T>
+/// Computes the depth (number of node levels, leaves included) of the tree that
+/// bulk loading will build for `number_of_elements` elements.
+///
+/// This mirrors the partitioning performed by [`bulk_load_recursive`]: on every
+/// level a node is split into `number_of_clusters_on_axis ^ DIMENSIONS`
+/// clusters, so a balanced cluster shrinks by that factor per level. The
+/// returned depth is the first level at which a balanced cluster fits into a
+/// single (leaf) node, i.e. holds at most `MAX_SIZE` elements.
+///
+/// Threading this depth through the recursion (instead of stopping each branch
+/// individually as soon as it reaches `MAX_SIZE` elements) guarantees that all
+/// leaves end up on the same level. Otherwise clusters whose size straddles
+/// `MAX_SIZE` -- some just below, some just above -- would produce leaves on
+/// different levels, yielding a malformed R-tree that violates the "all leaves
+/// share the same depth" invariant and makes a subsequent `insert` panic.
+fn bulk_load_depth<T, Params>(number_of_elements: usize) -> usize
+where
+    T: RTreeObject,
+    Params: RTreeParams,
+{
+    let m = Params::MAX_SIZE;
+    let dimensions = <T::Envelope as Envelope>::Point::DIMENSIONS;
+    let mut depth = 1;
+    let mut cluster_size = number_of_elements;
+    while cluster_size > m {
+        let number_of_clusters_on_axis =
+            calculate_number_of_clusters_on_axis::<T, Params>(cluster_size).max(2);
+        // Number of clusters this node is split into (across all axes).
+        let mut fanout = 1usize;
+        for _ in 0..dimensions {
+            fanout = fanout.saturating_mul(number_of_clusters_on_axis);
+        }
+        // Size of a balanced cluster on the next level. Rounding down selects
+        // the shallowest depth that keeps clusters from underflowing, which
+        // avoids creating nodes with fewer than `MIN_SIZE` children.
+        cluster_size /= fanout.max(2);
+        depth += 1;
+    }
+    depth
+}
+
+fn bulk_load_recursive<T, Params>(mut elements: Vec<T>, remaining_depth: usize) -> ParentNode<T>
 where
     T: RTreeObject,
     <T::Envelope as Envelope>::Point: Point,
     Params: RTreeParams,
 {
-    let m = Params::MAX_SIZE;
-    if elements.len() <= m {
+    if remaining_depth <= 1 {
         // Reached leaf level. Shrink excess capacity so the in-place collect
         // (which reuses the allocation when size_of::<T> == size_of::<RTreeNode<T>>)
         // doesn't preserve a massively over-sized buffer in the final tree node.
@@ -32,6 +72,7 @@ where
 
     let iterator = PartitioningTask::<_, Params> {
         number_of_clusters_on_axis,
+        remaining_depth,
         work_queue: vec![PartitioningState {
             current_axis: <T::Envelope as Envelope>::Point::DIMENSIONS,
             elements,
@@ -54,6 +95,7 @@ struct PartitioningState<T: RTreeObject> {
 struct PartitioningTask<T: RTreeObject, Params: RTreeParams> {
     work_queue: Vec<PartitioningState<T>>,
     number_of_clusters_on_axis: usize,
+    remaining_depth: usize,
     _params: core::marker::PhantomData<Params>,
 }
 
@@ -68,7 +110,7 @@ impl<T: RTreeObject, Params: RTreeParams> Iterator for PartitioningTask<T, Param
             } = next;
             if current_axis == 0 {
                 // Partitioning finished successfully on all axis. The remaining cluster forms a new node
-                let data = bulk_load_recursive::<_, Params>(elements);
+                let data = bulk_load_recursive::<_, Params>(elements, self.remaining_depth - 1);
                 return RTreeNode::Parent(data).into();
             } else {
                 // The cluster group needs to be partitioned further along the next axis
@@ -97,7 +139,8 @@ where
     <T::Envelope as Envelope>::Point: Point,
     Params: RTreeParams,
 {
-    bulk_load_recursive::<_, Params>(elements)
+    let depth = bulk_load_depth::<T, Params>(elements.len());
+    bulk_load_recursive::<_, Params>(elements, depth)
 }
 
 #[cfg(test)]

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -1391,4 +1391,62 @@ mod test {
             tree.root().sanity_check::<DefaultParams>(false);
         }
     }
+
+    #[test]
+    fn test_bulk_load_uniform_depth_and_insert() {
+        // Regression test: `bulk_load` used to build trees whose leaves ended up
+        // on different levels whenever the element count made some clusters land
+        // just above and some just below `MAX_SIZE`. Such a tree violates the
+        // "all leaves share the same depth" R-tree invariant, and inserting into
+        // it afterwards panicked with "This is a bug in rstar.".
+        //
+        // These 25 points reproduced the issue with the default parameters: the
+        // bulk-loaded tree had leaves on both level 2 and level 3, and the two
+        // trailing inserts hit the panic.
+        let bulk_nodes = vec![
+            [12, -8],
+            [-8, -9],
+            [-8, 9],
+            [8, -4],
+            [7, -10],
+            [-7, 4],
+            [6, -10],
+            [5, -11],
+            [-10, 6],
+            [5, -2],
+            [-11, -4],
+            [-2, -1],
+            [3, 0],
+            [3, -12],
+            [-5, -12],
+            [7, 4],
+            [8, 0],
+            [0, 4],
+            [-11, 5],
+            [-2, 10],
+            [7, 10],
+            [-10, -11],
+            [5, -5],
+            [11, 8],
+            [10, 8],
+        ];
+
+        let mut tree = RTree::bulk_load(bulk_nodes.clone());
+        // The freshly bulk-loaded tree must already be a valid R-tree (in
+        // particular all leaves on the same level). This assertion failed before
+        // the fix.
+        tree.root().sanity_check::<DefaultParams>(false);
+
+        // Inserting used to panic on the malformed tree.
+        tree.insert([-8, -1]);
+        tree.insert([3, 9]);
+        tree.root().sanity_check::<DefaultParams>(false);
+
+        assert_eq!(tree.size(), bulk_nodes.len() + 2);
+        for node in &bulk_nodes {
+            assert!(tree.contains(node));
+        }
+        assert!(tree.contains(&[-8, -1]));
+        assert!(tree.contains(&[3, 9]));
+    }
 }


### PR DESCRIPTION
`RTree::bulk_load` built the tree by recursively partitioning elements and turning any cluster with ≤ `MAX_SIZE` elements into a leaf. When the element count made sibling clusters straddle `MAX_SIZE` (some just below, some just above), the larger clusters were split one level deeper than the smaller ones, so leaves ended up on **different depths**.

Such a tree violates the R-tree invariant that all leaves share the same depth (the invariant `ParentNode::sanity_check` asserts). Queries still worked, but a later `insert` descends assuming uniform depth and panics with `"This is a bug in rstar."` on reaching a node that mixes leaf and parent children. Reproducible with default parameters in 2-D, e.g. bulk-loading 25 points and then inserting two more:

```rust
let mut t = RTree::bulk_load(vec![[12,-8],[-8,-9], /* … 25 points … */]);
t.insert([-8,-1]);
t.insert([3,9]); // panicked
```

Fix: compute the target tree depth up front and thread it through the recursion so every branch stops on the same level. Adds a regression test and a CHANGELOG entry. Full suite + fmt + clippy pass.

This is distinct from #197 (which is about `MAX_SIZE` compliance in higher dimensions — the repro here keeps every child count within `MAX_SIZE`) and from the long-closed #45 (a reinsertion bug; here the tree is already malformed straight out of `bulk_load`, before any insert). It does not attempt to fully solve #197.

- [x] I agree to follow the project's Code of Conduct.
