### PR TITLE
RTree/serde: Fix `UnsupportedType(Some(PhantomData))` on toml serialization

### DIFF
--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -184,6 +184,7 @@ where
 {
     root: ParentNode<T>,
     size: usize,
+    #[cfg_attr(feature = "serde", serde(skip))]
     _params: ::core::marker::PhantomData<Params>,
 }
 


### PR DESCRIPTION

- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

## Context

TOML doesn't support `PhantomData`, and I ran into this while testing https://github.com/mikwielgus/anyangle/pull/45.