### PR TITLE
Fix overflow panic draining an empty tree with integer coordinates

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Fixed
+- Fixed `drain_within_distance` panicking with an arithmetic overflow on an empty tree with integer coordinates. `locate_within_distance` was already guarded against this, its draining counterpart was not.
+
 
 # 0.13.0
 

--- a/rstar/src/algorithm/iterators.rs
+++ b/rstar/src/algorithm/iterators.rs
@@ -55,6 +55,8 @@ where
 {
     pub(crate) fn new(root: &'a ParentNode<T>, func: Func) -> Self {
         let current_nodes =
+            // Do not call `should_unpack_parent` on an empty root as
+            // its AABB is pathological and might make that function panic.
             if !root.children.is_empty() && func.should_unpack_parent(&root.envelope()) {
                 root.children.iter().collect()
             } else {

--- a/rstar/src/algorithm/removal.rs
+++ b/rstar/src/algorithm/removal.rs
@@ -100,7 +100,12 @@ where
         let m = Params::MIN_SIZE;
         let max_depth = (original_size as f32).log(m.max(2) as f32).ceil() as usize;
         let mut node_stack = Vec::with_capacity(max_depth);
-        node_stack.push((root, 0, 0));
+
+        // Do not push on an empty root onto `node_stack` as
+        // its AABB is pathological and might make `should_unpack_parent` panic.
+        if !root.children.is_empty() {
+            node_stack.push((root, 0, 0));
+        }
 
         DrainIterator {
             node_stack,
@@ -374,6 +379,23 @@ mod test {
         let sel_count = tree.locate_with_selection_function(sel).count();
         assert_eq!(sel_count, 0);
         assert_eq!(tree.size(), 1000 - 80 - 326);
+    }
+
+    #[test]
+    fn test_drain_within_distance_on_empty_tree() {
+        let mut tree: RTree<[f64; 3]> = RTree::new();
+        assert_eq!(tree.drain_within_distance([0.0, 0.0, 0.0], 10.0).count(), 0);
+
+        let mut tree: RTree<[i64; 3]> = RTree::new();
+        assert_eq!(tree.drain_within_distance([0, 0, 0], 10).count(), 0);
+
+        // A tree emptied by removals is in the same state: its root envelope
+        // has been reset to the empty envelope.
+        let mut tree: RTree<[i64; 3]> = RTree::new();
+        tree.insert([1, 2, 3]);
+        assert_eq!(tree.remove(&[1, 2, 3]), Some([1, 2, 3]));
+        assert_eq!(tree.drain_within_distance([0, 0, 0], 10).count(), 0);
+        assert_eq!(tree.size(), 0);
     }
 
     #[test]


### PR DESCRIPTION
- [x] I agree to follow the project's [code of conduct](https://github.com/georust/.github/blob/main/CODE_OF_CONDUCT.md).
- [x] I added an entry to the project's change log file if knowledge of this change could be valuable to users.
---

`drain_within_distance` panicked with an arithmetic overflow on an empty tree with integer coordinates, because the removal function was handed the empty root envelope whose corners are the scalar type's maximum and minimum. The drain iterator now seeds its stack only when the root has children, matching the guard `SelectionIterator::new` already has. `test_drain_within_distance_on_empty_tree` covers a tree that was never filled and one emptied by removals, and it fails with the overflow if the guard is removed.
