### PR TITLE
Remove `RTreeObject` trait bound on struct def. via default generic param.

### DIFF
--- a/rstar/CHANGELOG.md
+++ b/rstar/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.14.0
+
+## Added
+- Added generic parameter, `E`, to avoid contagious `T: RTreeObject` bound in struct definitions.
 
 # 0.13.0
 

--- a/rstar/src/node.rs
+++ b/rstar/src/node.rs
@@ -13,21 +13,18 @@ use serde::{Deserialize, Serialize};
 #[cfg_attr(
     feature = "serde",
     serde(bound(
-        serialize = "T: Serialize, T::Envelope: Serialize",
-        deserialize = "T: Deserialize<'de>, T::Envelope: Deserialize<'de>"
+        serialize = "T: Serialize, E: Serialize",
+        deserialize = "T: Deserialize<'de>, E: Deserialize<'de>"
     ))
 )]
 /// An internal tree node.
 ///
 /// For most applications, using this type should not be required.
-pub enum RTreeNode<T>
-where
-    T: RTreeObject,
-{
+pub enum RTreeNode<T, E = <T as RTreeObject>::Envelope> {
     /// A leaf node, only containing the r-tree object
     Leaf(T),
     /// A parent node containing several child nodes
-    Parent(ParentNode<T>),
+    Parent(ParentNode<T, E>),
 }
 
 /// Represents an internal parent node.
@@ -36,12 +33,9 @@ where
 /// node's envelope and its children.
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct ParentNode<T>
-where
-    T: RTreeObject,
-{
-    pub(crate) children: Vec<RTreeNode<T>>,
-    pub(crate) envelope: T::Envelope,
+pub struct ParentNode<T, E = <T as RTreeObject>::Envelope> {
+    pub(crate) children: Vec<RTreeNode<T, E>>,
+    pub(crate) envelope: E,
 }
 
 impl<T> RTreeObject for RTreeNode<T>
@@ -59,10 +53,7 @@ where
 }
 
 #[doc(hidden)]
-impl<T> RTreeNode<T>
-where
-    T: RTreeObject,
-{
+impl<T, E> RTreeNode<T, E> {
     pub fn is_leaf(&self) -> bool {
         match self {
             RTreeNode::Leaf(..) => true,

--- a/rstar/src/rtree.rs
+++ b/rstar/src/rtree.rs
@@ -145,6 +145,7 @@ where
 /// * `T`: The type of objects stored in the r-tree.
 /// * `Params`: Compile time parameters that change the r-tree's internal layout. Refer to the
 ///   [RTreeParams] trait for more information.
+/// * `E`: The envelope type used by tree nodes. Defaults to `<T as RTreeObject>::Envelope`.
 ///
 /// # Defining methods generic over r-trees
 /// If a library defines a method that should be generic over the r-tree type signature, make
@@ -173,16 +174,15 @@ where
 #[cfg_attr(
     feature = "serde",
     serde(bound(
-        serialize = "T: Serialize, T::Envelope: Serialize",
-        deserialize = "T: Deserialize<'de>, T::Envelope: Deserialize<'de>"
+        serialize = "T: Serialize, E: Serialize",
+        deserialize = "T: Deserialize<'de>, E: Deserialize<'de>"
     ))
 )]
-pub struct RTree<T, Params = DefaultParams>
+pub struct RTree<T, Params = DefaultParams, E = <T as RTreeObject>::Envelope>
 where
     Params: RTreeParams,
-    T: RTreeObject,
 {
-    root: ParentNode<T>,
+    root: ParentNode<T, E>,
     size: usize,
     #[cfg_attr(feature = "serde", serde(skip))]
     _params: ::core::marker::PhantomData<Params>,


### PR DESCRIPTION
Bounds on struct definitions, unlike bounds on functions, are usually unidiomatic in Rust, and it is usually possible to rewrite the code so that there are only bounds on functions, and nothing on the type definition itself. If you care about this, it becomes a contagious problem to rely on `rstar` in your own generic code, because the `T: RTreeObject` bound propagates upward.

For example,

```rust
pub struct Layout<T: RTreeObject> {
    objects: Vec<T>,
    rtree: RTree<T>,
}
```

must have an `RTreeObject` bound on `T`, even though this code's authors may not want to expose that to their downstream in their code's public interface.

(the above of course also applies to enums)

See also this Stack Overflow answer: https://stackoverflow.com/a/66369912

This PR is a proposal to solve this problem by adding an additional generic parameter `E` to `rstar`'s types that defaults to `RTreeObject::Envelope`.

- [x] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [x] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

