### PR TITLE
chore(rstar): Get rid of unnecessary trait bounds

### DIFF
--- a/rstar/src/aabb.rs
+++ b/rstar/src/aabb.rs
@@ -20,17 +20,14 @@ use serde::{Deserialize, Serialize};
 /// type will result in an n-dimensional bounding box.
 #[derive(Clone, Debug, Copy, PartialEq, Eq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
-pub struct AABB<P>
-where
-    P: Point,
-{
+pub struct AABB<P> {
     lower: P,
     upper: P,
 }
 
 impl<P> AABB<P>
 where
-    P: Point,
+    P: Clone,
 {
     /// Returns the AABB encompassing a single point.
     pub fn from_point(p: P) -> Self {
@@ -55,7 +52,12 @@ where
     pub fn upper(&self) -> P {
         self.upper.clone()
     }
+}
 
+impl<P> AABB<P>
+where
+    P: Point,
+{
     /// Creates a new AABB encompassing two points.
     pub fn from_corners(p1: P, p2: P) -> Self {
         Self {

--- a/rstar/src/point.rs
+++ b/rstar/src/point.rs
@@ -269,9 +269,9 @@ pub trait PointExt: Point {
 }
 
 #[inline]
-pub fn min_inline<S>(a: S, b: S) -> S
+pub(crate) fn min_inline<S>(a: S, b: S) -> S
 where
-    S: RTreeNum,
+    S: PartialOrd,
 {
     if a < b {
         a
@@ -281,9 +281,9 @@ where
 }
 
 #[inline]
-pub fn max_inline<S>(a: S, b: S) -> S
+pub(crate) fn max_inline<S>(a: S, b: S) -> S
 where
-    S: RTreeNum,
+    S: PartialOrd,
 {
     if a > b {
         a

--- a/rstar/src/primitives/geom_with_data.rs
+++ b/rstar/src/primitives/geom_with_data.rs
@@ -31,7 +31,7 @@ use crate::{envelope::Envelope, object::Distance};
 /// ```
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct GeomWithData<R: RTreeObject, T> {
+pub struct GeomWithData<R, T> {
     geom: R,
     /// Data to be associated with the geometry being stored in the [`RTree`](crate::RTree).
     pub data: T,
@@ -63,7 +63,7 @@ impl<R: PointDistance, T> PointDistance for GeomWithData<R, T> {
     }
 }
 
-impl<R: RTreeObject, T> GeomWithData<R, T> {
+impl<R, T> GeomWithData<R, T> {
     /// Create a new [GeomWithData] struct using the provided geometry and data.
     pub fn new(geom: R, data: T) -> Self {
         Self { geom, data }

--- a/rstar/src/primitives/line.rs
+++ b/rstar/src/primitives/line.rs
@@ -24,20 +24,14 @@ use num_traits::{One, Zero};
 /// ```
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Line<P>
-where
-    P: Point,
-{
+pub struct Line<P> {
     /// The line's start point
     pub from: P,
     /// The line's end point.
     pub to: P,
 }
 
-impl<P> Line<P>
-where
-    P: Point,
-{
+impl<P> Line<P> {
     /// Creates a new line between two points.
     pub fn new(from: P, to: P) -> Self {
         Line { from, to }

--- a/rstar/src/primitives/object_ref.rs
+++ b/rstar/src/primitives/object_ref.rs
@@ -12,7 +12,7 @@ use core::ops::Deref;
 /// **Note:** the wrapper implements [RTreeObject] and referenced object `T` can be
 /// accessed via an implementation of `Deref<Target=T>`.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ObjectRef<'a, T: RTreeObject> {
+pub struct ObjectRef<'a, T> {
     inner: &'a T,
 }
 
@@ -43,14 +43,14 @@ impl<T: PointDistance> PointDistance for ObjectRef<'_, T> {
     }
 }
 
-impl<'a, T: RTreeObject> ObjectRef<'a, T> {
+impl<'a, T> ObjectRef<'a, T> {
     /// Create a new [ObjectRef] struct using the object.
     pub fn new(inner: &'a T) -> Self {
         Self { inner }
     }
 }
 
-impl<T: RTreeObject> Deref for ObjectRef<'_, T> {
+impl<T> Deref for ObjectRef<'_, T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {

--- a/rstar/src/primitives/rectangle.rs
+++ b/rstar/src/primitives/rectangle.rs
@@ -14,19 +14,16 @@ use crate::{aabb::AABB, object::Distance};
 /// `P`: The rectangle's [Point] type.
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
-pub struct Rectangle<P>
-where
-    P: Point,
-{
+pub struct Rectangle<P> {
     aabb: AABB<P>,
 }
 
-impl<P> Rectangle<P>
-where
-    P: Point,
-{
+impl<P> Rectangle<P> {
     /// Creates a new rectangle defined by two corners.
-    pub fn from_corners(corner_1: P, corner_2: P) -> Self {
+    pub fn from_corners(corner_1: P, corner_2: P) -> Self
+    where
+        P: Point,
+    {
         AABB::from_corners(corner_1, corner_2).into()
     }
 
@@ -34,7 +31,9 @@ where
     pub fn from_aabb(aabb: AABB<P>) -> Self {
         Rectangle { aabb }
     }
+}
 
+impl<P: Clone> Rectangle<P> {
     /// Returns the rectangle's lower corner.
     ///
     /// This is the point contained within the rectangle with the smallest coordinate value in each
@@ -52,10 +51,7 @@ where
     }
 }
 
-impl<P> From<AABB<P>> for Rectangle<P>
-where
-    P: Point,
-{
+impl<P> From<AABB<P>> for Rectangle<P> {
     fn from(aabb: AABB<P>) -> Self {
         Self::from_aabb(aabb)
     }


### PR DESCRIPTION
- [X] I agree to follow the project's [code of conduct](https://github.com/georust/geo/blob/master/CODE_OF_CONDUCT.md).
- [ ] I added an entry to `rstar/CHANGELOG.md` if knowledge of this change could be valuable to users.
---

This has the same motivation as #247 (but is orthogonal/independent to that), particularly that these trait bounds "bleed" into downstream usage, e.g. in https://docs.rs/polygon_unionfind and https://github.com/mikwielgus/anyangle .